### PR TITLE
Add `markdown_to_blockdoc` support

### DIFF
--- a/.claude/commands/add-to-changelog.md
+++ b/.claude/commands/add-to-changelog.md
@@ -1,0 +1,51 @@
+# Update Changelog
+
+This command adds a new entry to the project's CHANGELOG.md file.
+
+## Usage
+
+```
+/add-to-changelog <version> <change_type> <message>
+```
+
+Where:
+- `<version>` is the version number (e.g., "1.1.0")
+- `<change_type>` is one of: "added", "changed", "deprecated", "removed", "fixed", "security"
+- `<message>` is the description of the change
+
+## Examples
+
+```
+/add-to-changelog 1.1.0 added "New markdown to BlockDoc conversion feature"
+```
+
+```
+/add-to-changelog 1.0.2 fixed "Bug in HTML renderer causing incorrect output"
+```
+
+## Description
+
+This command will:
+
+1. Check if a CHANGELOG.md file exists and create one if needed
+2. Look for an existing section for the specified version
+   - If found, add the new entry under the appropriate change type section
+   - If not found, create a new version section with today's date
+3. Format the entry according to Keep a Changelog conventions
+4. Commit the changes if requested
+
+The CHANGELOG follows the [Keep a Changelog](https://keepachangelog.com/) format and [Semantic Versioning](https://semver.org/).
+
+## Implementation
+
+The command should:
+
+1. Parse the arguments to extract version, change type, and message
+2. Read the existing CHANGELOG.md file if it exists
+3. If the file doesn't exist, create a new one with standard header
+4. Check if the version section already exists
+5. Add the new entry in the appropriate section
+6. Write the updated content back to the file
+7. Suggest committing the changes
+
+Remember to update the package version in `__init__.py` and `setup.py` if this is a new version.

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203
-exclude = .git,__pycache__,build,dist,.pytest_cache,.ruff_cache

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+exclude = .git,__pycache__,build,dist,.pytest_cache,.ruff_cache

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -22,13 +22,10 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .[dev]
     
-    - name: Lint with flake8
+    - name: Lint and check formatting with ruff
       run: |
-        flake8 blockdoc tests
-    
-    - name: Check formatting with black
-      run: |
-        black --check blockdoc tests
+        ruff check blockdoc tests examples
+        ruff format --check blockdoc tests examples
     
     - name: Type check with mypy
       run: |

--- a/.repomixignore
+++ b/.repomixignore
@@ -1,0 +1,4 @@
+# Add patterns to ignore here, one per line
+# Example:
+# *.log
+# tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2025-04-25
+
+### Added
+
+- New `markdown_to_blockdoc` converter for transforming Markdown documents to BlockDoc format
+- Comprehensive parser that handles all core Markdown elements:
+  - Headings (ATX and Setext styles)
+  - Paragraphs with proper line break handling
+  - Lists (ordered and unordered)
+  - Code blocks with language detection
+  - Block quotes with attribution
+  - Images with captions
+  - Horizontal rules
+- Semantic ID generation based on content
+- Example implementation in `examples/markdown_conversion_example.py`
+- Test suite for the converter functionality
+
+## [1.0.1] - 2024-09-15
+
+### Fixed
+
+- Fixed pyproject.toml syntax error and installation method in CI
+
+## [1.0.0] - 2024-09-01
+
+### Added
+
+- Initial release of BlockDoc
+- Core Block and BlockDocDocument classes
+- HTML and Markdown renderers
+- JSON schema validation
+- Basic utility functions

--- a/blockdoc/__init__.py
+++ b/blockdoc/__init__.py
@@ -1,7 +1,8 @@
 """
 BlockDoc
 
-A simple, powerful standard for structured content that works beautifully with LLMs, humans, and modern editors.
+A simple, powerful standard for structured content that works beautifully with LLMs,
+humans, and modern editors.
 """
 
 from blockdoc.core.block import Block

--- a/blockdoc/__init__.py
+++ b/blockdoc/__init__.py
@@ -5,9 +5,9 @@ A simple, powerful standard for structured content that works beautifully with L
 humans, and modern editors.
 """
 
+from blockdoc.conversions.markdown import markdown_to_blockdoc
 from blockdoc.core.block import Block
 from blockdoc.core.document import BlockDocDocument
-from blockdoc.conversions.markdown import markdown_to_blockdoc
 from blockdoc.renderers.html import render_to_html
 from blockdoc.renderers.markdown import render_to_markdown
 from blockdoc.schema.loader import schema

--- a/blockdoc/__init__.py
+++ b/blockdoc/__init__.py
@@ -6,6 +6,7 @@ A simple, powerful standard for structured content that works beautifully with L
 
 from blockdoc.core.block import Block
 from blockdoc.core.document import BlockDocDocument
+from blockdoc.conversions.markdown import markdown_to_blockdoc
 from blockdoc.renderers.html import render_to_html
 from blockdoc.renderers.markdown import render_to_markdown
 from blockdoc.schema.loader import schema
@@ -15,6 +16,7 @@ __all__ = [
     "BlockDocDocument",
     "render_to_html",
     "render_to_markdown",
+    "markdown_to_blockdoc",
     "schema",
 ]
 

--- a/blockdoc/__init__.py
+++ b/blockdoc/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "schema",
 ]
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/blockdoc/conversions/__init__.py
+++ b/blockdoc/conversions/__init__.py
@@ -1,0 +1,8 @@
+"""BlockDoc Conversion Utilities
+
+Utilities for converting between BlockDoc and other formats
+"""
+
+from blockdoc.conversions.markdown import markdown_to_blockdoc
+
+__all__ = ["markdown_to_blockdoc"]

--- a/blockdoc/conversions/markdown.py
+++ b/blockdoc/conversions/markdown.py
@@ -1,0 +1,462 @@
+"""Markdown to BlockDoc Converter
+
+Utilities for converting Markdown documents to BlockDoc format
+"""
+
+import re
+import uuid
+from typing import Any, Dict, List, Optional
+
+from blockdoc.core.block import Block
+from blockdoc.core.document import BlockDocDocument
+
+
+def markdown_to_blockdoc(
+    markdown_text: str,
+    title: str = "Untitled Document",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> BlockDocDocument:
+    """
+    Convert a Markdown document to BlockDoc format
+
+    Args:
+        markdown_text (str): The markdown content to convert
+        title (str, optional): Document title. Defaults to "Untitled Document".
+        metadata (Dict, optional): Optional document metadata. Defaults to None.
+
+    Returns:
+        BlockDocDocument: A BlockDoc document generated from the markdown
+    """
+    if metadata is None:
+        metadata = {}
+
+    # Create a new BlockDoc document
+    doc = BlockDocDocument({"title": title, "metadata": metadata})
+
+    # Extract the title from markdown if available and not explicitly provided
+    if title == "Untitled Document":
+        first_line = markdown_text.strip().split("\n")[0]
+        if first_line.startswith("# "):
+            extracted_title = first_line[2:].strip()
+            if extracted_title:
+                doc.article["title"] = extracted_title
+                # Remove the title line from the markdown
+                markdown_text = "\n".join(markdown_text.strip().split("\n")[1:]).strip()
+
+    # Split the markdown into blocks
+    blocks = split_markdown_into_blocks(markdown_text)
+
+    # Convert each block to a BlockDoc block and add to document
+    for block in blocks:
+        blockdoc_block = convert_block_to_blockdoc(block)
+        if blockdoc_block:
+            doc.add_block(blockdoc_block)
+
+    return doc
+
+
+def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
+    """
+    Split a markdown document into discrete blocks for conversion
+
+    Args:
+        markdown_text (str): Markdown content to split
+
+    Returns:
+        List[Dict[str, str]]: List of block data with type and content
+    """
+    if not markdown_text.strip():
+        return []
+
+    lines = markdown_text.split("\n")
+    blocks = []
+    current_block = None
+
+    # Various state tracking variables
+    in_code_block = False
+    code_lang = ""
+    in_list = False
+    list_items = []
+    list_type = ""
+    current_list_indent = 0
+    in_quote = False
+    quote_lines = []
+    quote_has_attribution = False
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped_line = line.strip()
+
+        # Handle code blocks
+        if stripped_line.startswith("```"):
+            if not in_code_block:
+                # Start of code block
+                if current_block:
+                    blocks.append(current_block)
+                    current_block = None
+
+                in_code_block = True
+                code_lang = stripped_line[3:].strip() or "plain"
+                current_block = {"type": "code", "content": "", "language": code_lang}
+            else:
+                # End of code block
+                in_code_block = False
+                blocks.append(current_block)
+                current_block = None
+            i += 1
+            continue
+        elif in_code_block:
+            # Inside code block - preserve all formatting including empty lines
+            if current_block["content"]:
+                current_block["content"] += "\n"
+            current_block["content"] += line
+            i += 1
+            continue
+
+        # Handle horizontal rules
+        if (
+            re.match(r"^(---|\*\*\*|___)\s*$", stripped_line)
+            and not in_quote
+            and not in_list
+        ):
+            if current_block:
+                blocks.append(current_block)
+            blocks.append({"type": "divider", "content": ""})
+            current_block = None
+            i += 1
+            continue
+
+        # Handle headings (ATX style: # Heading)
+        heading_match = re.match(r"^(#{1,6})\s+(.+)$", stripped_line)
+        if heading_match and not in_quote and not in_list:
+            if current_block:
+                blocks.append(current_block)
+
+            level = len(heading_match.group(1))
+            content = heading_match.group(2).strip()
+            blocks.append({"type": "heading", "content": content, "level": level})
+            current_block = None
+            i += 1
+            continue
+
+        # Handle Setext-style headings (Heading\n=====)
+        if (
+            i + 1 < len(lines)
+            and not in_quote
+            and not in_list
+            and current_block
+            and current_block["type"] == "text"
+        ):
+            next_line = lines[i + 1].strip()
+            if re.match(r"^=+$", next_line):
+                # Level 1 heading
+                content = current_block["content"].strip()
+                blocks.pop()  # Remove the text block we just added
+                blocks.append({"type": "heading", "content": content, "level": 1})
+                current_block = None
+                i += 2  # Skip the underline
+                continue
+            elif re.match(r"^-+$", next_line):
+                # Level 2 heading
+                content = current_block["content"].strip()
+                blocks.pop()  # Remove the text block we just added
+                blocks.append({"type": "heading", "content": content, "level": 2})
+                current_block = None
+                i += 2  # Skip the underline
+                continue
+
+        # Handle images: ![alt](url)
+        image_match = re.match(r"^!\[([^\]]*)\]\(([^)]+)\)(?:\s*(.*))?$", stripped_line)
+        if image_match and not in_quote and not in_list:
+            if current_block:
+                blocks.append(current_block)
+
+            alt_text = image_match.group(1) or ""
+            url = image_match.group(2)
+            caption = image_match.group(3) or None
+
+            img_block = {"type": "image", "content": "", "url": url, "alt": alt_text}
+            if caption:
+                img_block["caption"] = caption
+
+            blocks.append(img_block)
+            current_block = None
+            i += 1
+            continue
+
+        # Handle block quotes
+        if stripped_line.startswith(">") and not in_list:
+            quote_line = stripped_line[1:].strip()
+
+            # Check for attribution line
+            attribution_match = re.match(r"^[\u2014-]\s+(.+)$", quote_line)
+
+            if not in_quote:
+                # Start of quote
+                if current_block:
+                    blocks.append(current_block)
+                in_quote = True
+                quote_lines = []
+                quote_has_attribution = False
+
+                if attribution_match:
+                    quote_has_attribution = True
+                    attribution = attribution_match.group(1)
+                    # Don't add this to quote_lines as it's attribution
+                else:
+                    quote_lines.append(quote_line)
+            else:
+                # Continuing quote
+                if attribution_match:
+                    quote_has_attribution = True
+                    attribution = attribution_match.group(1)
+                    # Don't add this to quote_lines as it's attribution
+                else:
+                    quote_lines.append(quote_line)
+
+            i += 1
+            continue
+        elif in_quote:
+            # End of quote block
+            quote_content = "\n".join(quote_lines).strip()
+            quote_block = {"type": "quote", "content": quote_content}
+
+            if quote_has_attribution:
+                quote_block["attribution"] = attribution
+
+            blocks.append(quote_block)
+            in_quote = False
+            current_block = None
+            # Don't increment i, process this line again
+            continue
+
+        # Handle lists
+        list_match = re.match(r"^(\s*)([-*+]|\d+\.)\s+(.+)$", stripped_line)
+        if list_match:
+            indent = len(list_match.group(1))
+            marker = list_match.group(2)
+            item_content = list_match.group(3)
+            is_ordered = bool(re.match(r"\d+\.", marker))
+
+            if not in_list:
+                # Start of a new list
+                if current_block:
+                    blocks.append(current_block)
+
+                in_list = True
+                current_list_indent = indent
+                list_items = [item_content]
+                list_type = "ordered" if is_ordered else "unordered"
+            else:
+                # Continuing a list
+                # Check if this is a new list (different indent or type)
+                if (indent != current_list_indent) or (
+                    is_ordered != (list_type == "ordered")
+                ):
+                    # Different list - end current one and start new
+                    blocks.append(
+                        {
+                            "type": "list",
+                            "content": "",
+                            "items": list_items,
+                            "list_type": list_type,
+                        }
+                    )
+                    list_items = [item_content]
+                    current_list_indent = indent
+                    list_type = "ordered" if is_ordered else "unordered"
+                else:
+                    # Same list - add item
+                    list_items.append(item_content)
+
+            i += 1
+            continue
+        elif in_list and stripped_line == "":
+            # Empty line - check if next non-empty line continues the list
+            next_i = i + 1
+            while next_i < len(lines) and not lines[next_i].strip():
+                next_i += 1
+
+            if next_i < len(lines):
+                next_line = lines[next_i]
+                next_match = re.match(r"^(\s*)([-*+]|\d+\.)\s+(.+)$", next_line)
+                if next_match and len(next_match.group(1)) == current_list_indent:
+                    # Next line continues this list after blank line(s)
+                    i = next_i
+                    continue
+
+            # End of list
+            blocks.append(
+                {
+                    "type": "list",
+                    "content": "",
+                    "items": list_items,
+                    "list_type": list_type,
+                }
+            )
+            in_list = False
+            current_block = None
+            i += 1
+            continue
+        elif in_list:
+            # Not a list item - end list and process line again
+            blocks.append(
+                {
+                    "type": "list",
+                    "content": "",
+                    "items": list_items,
+                    "list_type": list_type,
+                }
+            )
+            in_list = False
+            # Don't increment i, process this line again
+            continue
+
+        # Handle normal text blocks with proper paragraph breaks (blank lines)
+        if stripped_line or (current_block and current_block["type"] == "text"):
+            if (
+                stripped_line == ""
+                and current_block
+                and current_block["type"] == "text"
+            ):
+                # Empty line after text - end paragraph
+                blocks.append(current_block)
+                current_block = None
+            elif not current_block:
+                # Start new text block
+                current_block = {"type": "text", "content": stripped_line}
+            else:
+                # Continue existing text block
+                # In Markdown, single line breaks don't create new paragraphs
+                # Add a space unless the line was actually empty
+                if current_block["content"] and stripped_line:
+                    current_block["content"] += "\n" + stripped_line
+                elif stripped_line:
+                    current_block["content"] += stripped_line
+                else:
+                    # This is an empty line within a text block (preserve it)
+                    current_block["content"] += "\n"
+
+        i += 1
+
+    # Handle unclosed blocks
+    if current_block:
+        blocks.append(current_block)
+
+    if in_quote:
+        quote_content = "\n".join(quote_lines).strip()
+        quote_block = {"type": "quote", "content": quote_content}
+        if quote_has_attribution:
+            quote_block["attribution"] = attribution
+        blocks.append(quote_block)
+
+    if in_list:
+        blocks.append(
+            {"type": "list", "content": "", "items": list_items, "list_type": list_type}
+        )
+
+    if in_code_block:
+        # Unclosed code block - best effort to add it
+        blocks.append(current_block)
+
+    return blocks
+
+
+def convert_block_to_blockdoc(block: Dict[str, str]) -> Optional[Block]:
+    """
+    Convert a markdown block to a BlockDoc block
+
+    Args:
+        block (Dict[str, str]): Block data containing type and content
+
+    Returns:
+        Optional[Block]: A Block instance or None if conversion fails
+    """
+    block_type = block.get("type")
+
+    # Generate a semantic ID based on content
+    block_id = generate_block_id(block)
+
+    try:
+        if block_type == "text":
+            content = block.get("content", "").strip()
+            if not content:  # Skip empty text blocks
+                return None
+            return Block.text(block_id, content)
+
+        elif block_type == "heading":
+            level = block.get("level", 2)
+            content = block.get("content", "").strip()
+            return Block.heading(block_id, level, content)
+
+        elif block_type == "code":
+            language = block.get("language", "plain")
+            content = block.get("content", "").strip()
+            return Block.code(block_id, language, content)
+
+        elif block_type == "image":
+            url = block.get("url", "")
+            alt = block.get("alt", "")
+            caption = block.get("caption")
+            return Block.image(block_id, url, alt, caption)
+
+        elif block_type == "list":
+            items = block.get("items", [])
+            list_type = block.get("list_type", "unordered")
+            return Block.list(block_id, items, list_type)
+
+        elif block_type == "quote":
+            content = block.get("content", "").strip()
+            attribution = block.get("attribution")
+            return Block.quote(block_id, content, attribution)
+
+        elif block_type == "divider":
+            return Block.divider(block_id)
+
+        else:
+            # Unknown block type, convert to text
+            content = block.get("content", "").strip()
+            return Block.text(block_id, content) if content else None
+    except Exception as e:
+        # If anything goes wrong, return None
+        print(f"Error converting block to BlockDoc: {e}")
+        return None
+
+
+def generate_block_id(block: Dict[str, str]) -> str:
+    """
+    Generate a semantic ID for a block based on its content
+
+    Args:
+        block (Dict[str, str]): Block data
+
+    Returns:
+        str: A semantic ID for the block
+    """
+    block_type = block.get("type")
+    content = block.get("content", "").strip()
+
+    # For headings, create an ID from the content
+    if block_type == "heading" and content:
+        # Convert to lowercase, replace spaces with hyphens, remove non-alphanumeric chars
+        slug = re.sub(r"[^\w\s-]", "", content.lower())
+        slug = re.sub(r"[\s-]+", "-", slug).strip("-")
+        return slug[:40]  # Limit length of ID
+
+    # For other block types, use the type as a prefix
+    if block_type:
+        prefix = block_type
+
+        # For specific block types, enhance the ID
+        if block_type == "code" and block.get("language"):
+            prefix = f"code-{block.get('language')}"
+        elif block_type == "list":
+            prefix = f"{block.get('list_type', 'unordered')}-list"
+
+        # Add a short random suffix to ensure uniqueness
+        suffix = str(uuid.uuid4())[:8]
+        return f"{prefix}-{suffix}"
+
+    # Fallback to a generic ID
+    return f"block-{str(uuid.uuid4())[:8]}"

--- a/blockdoc/conversions/markdown.py
+++ b/blockdoc/conversions/markdown.py
@@ -115,11 +115,7 @@ def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
             continue
 
         # Handle horizontal rules
-        if (
-            re.match(r"^(---|\*\*\*|___)\s*$", stripped_line)
-            and not in_quote
-            and not in_list
-        ):
+        if re.match(r"^(---|\*\*\*|___)\s*$", stripped_line) and not in_quote and not in_list:
             if current_block:
                 blocks.append(current_block)
             blocks.append({"type": "divider", "content": ""})
@@ -141,13 +137,7 @@ def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
             continue
 
         # Handle Setext-style headings (Heading\n=====)
-        if (
-            i + 1 < len(lines)
-            and not in_quote
-            and not in_list
-            and current_block
-            and current_block["type"] == "text"
-        ):
+        if i + 1 < len(lines) and not in_quote and not in_list and current_block and current_block["type"] == "text":
             next_line = lines[i + 1].strip()
             if re.match(r"^=+$", next_line):
                 # Level 1 heading
@@ -251,9 +241,7 @@ def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
             else:
                 # Continuing a list
                 # Check if this is a new list (different indent or type)
-                if (indent != current_list_indent) or (
-                    is_ordered != (list_type == "ordered")
-                ):
+                if (indent != current_list_indent) or (is_ordered != (list_type == "ordered")):
                     # Different list - end current one and start new
                     blocks.append(
                         {
@@ -315,11 +303,7 @@ def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
 
         # Handle normal text blocks with proper paragraph breaks (blank lines)
         if stripped_line or (current_block and current_block["type"] == "text"):
-            if (
-                stripped_line == ""
-                and current_block
-                and current_block["type"] == "text"
-            ):
+            if stripped_line == "" and current_block and current_block["type"] == "text":
                 # Empty line after text - end paragraph
                 blocks.append(current_block)
                 current_block = None
@@ -352,9 +336,7 @@ def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]:
         blocks.append(quote_block)
 
     if in_list:
-        blocks.append(
-            {"type": "list", "content": "", "items": list_items, "list_type": list_type}
-        )
+        blocks.append({"type": "list", "content": "", "items": list_items, "list_type": list_type})
 
     if in_code_block:
         # Unclosed code block - best effort to add it

--- a/blockdoc/conversions/markdown.py
+++ b/blockdoc/conversions/markdown.py
@@ -439,7 +439,7 @@ def generate_block_id(block: Dict[str, str]) -> str:
 
     # For headings, create an ID from the content
     if block_type == "heading" and content:
-        # Convert to lowercase, replace spaces with hyphens, remove non-alphanumeric chars
+        # Convert to lowercase, replace spaces with hyphens, remove non-alphanumeric
         slug = re.sub(r"[^\w\s-]", "", content.lower())
         slug = re.sub(r"[\s-]+", "-", slug).strip("-")
         return slug[:40]  # Limit length of ID

--- a/blockdoc/core/block.py
+++ b/blockdoc/core/block.py
@@ -41,10 +41,7 @@ class Block:
             raise ValueError("Block ID is required")
 
         if not data.get("type") or data.get("type") not in ALLOWED_TYPES:
-            raise ValueError(
-                f"Invalid block type: {data.get('type')}. "
-                f"Allowed types are: {', '.join(ALLOWED_TYPES)}"
-            )
+            raise ValueError(f"Invalid block type: {data.get('type')}. Allowed types are: {', '.join(ALLOWED_TYPES)}")
 
         # Basic properties all blocks have
         self.id = data["id"]
@@ -60,9 +57,7 @@ class Block:
                 python_prop = "list_type"
 
             if python_prop not in data and prop not in data:
-                raise ValueError(
-                    f'Block of type "{self.type}" requires property "{prop}"'
-                )
+                raise ValueError(f'Block of type "{self.type}" requires property "{prop}"')
 
             # Check both formats and prefer snake_case
             if python_prop in data:

--- a/blockdoc/renderers/html.py
+++ b/blockdoc/renderers/html.py
@@ -25,11 +25,7 @@ def render_to_html(article):
     Returns:
         str: HTML representation
     """
-    if (
-        not article
-        or "blocks" not in article
-        or not isinstance(article["blocks"], list)
-    ):
+    if not article or "blocks" not in article or not isinstance(article["blocks"], list):
         raise ValueError("Invalid article structure")
 
     html = [
@@ -60,7 +56,9 @@ def render_block(block):
     block_type = block.get("type", "")
 
     # Wrapper with block ID and type as data attributes
-    open_wrapper = f'<div class="blockdoc-block blockdoc-{block_type}" data-block-id="{block_id}" data-block-type="{block_type}">'
+    open_wrapper = (
+        f'<div class="blockdoc-block blockdoc-{block_type}" data-block-id="{block_id}" data-block-type="{block_type}">'
+    )
     close_wrapper = "</div>"
 
     if block_type == "text":
@@ -219,9 +217,7 @@ def render_quote_block(block):
     html = f'<blockquote class="blockdoc-quote">{markdown(content)}</blockquote>'
 
     if attribution:
-        html += (
-            f'<cite class="blockdoc-attribution">{sanitize_html(attribution)}</cite>'
-        )
+        html += f'<cite class="blockdoc-attribution">{sanitize_html(attribution)}</cite>'
 
     return html
 
@@ -315,9 +311,7 @@ def extract_youtube_id(url):
         return youtu_be_match.group(1)
 
     # Check for youtube.com format
-    youtube_match = re.match(
-        r"https?://(?:www\.)?youtube\.com/watch\?v=([a-zA-Z0-9_-]+)", url
-    )
+    youtube_match = re.match(r"https?://(?:www\.)?youtube\.com/watch\?v=([a-zA-Z0-9_-]+)", url)
     if youtube_match:
         return youtube_match.group(1)
 

--- a/blockdoc/renderers/markdown.py
+++ b/blockdoc/renderers/markdown.py
@@ -17,11 +17,7 @@ def render_to_markdown(article):
     Returns:
         str: Markdown representation
     """
-    if (
-        not article
-        or "blocks" not in article
-        or not isinstance(article["blocks"], list)
-    ):
+    if not article or "blocks" not in article or not isinstance(article["blocks"], list):
         raise ValueError("Invalid article structure")
 
     markdown = [f"# {article['title']}", ""]
@@ -35,19 +31,13 @@ def render_to_markdown(article):
 
         if metadata.get("publishedDate"):
             try:
-                date = datetime.fromisoformat(
-                    metadata["publishedDate"].replace("Z", "+00:00")
-                )
+                date = datetime.fromisoformat(metadata["publishedDate"].replace("Z", "+00:00"))
                 markdown.append(f"> Published: {date.strftime('%a %b %d %Y')}")
             except (ValueError, AttributeError):
                 # If date parsing fails, just use the raw value
                 markdown.append(f"> Published: {metadata['publishedDate']}")
 
-        if (
-            metadata.get("tags")
-            and isinstance(metadata["tags"], list)
-            and metadata["tags"]
-        ):
+        if metadata.get("tags") and isinstance(metadata["tags"], list) and metadata["tags"]:
             markdown.append(f"> Tags: {', '.join(metadata['tags'])}")
 
         markdown.append("")

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -19,9 +19,7 @@ try:
     import pygments
 except ImportError:
     print("Installing required dependencies...")
-    subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "markdown", "pygments", "jsonschema"]
-    )
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "markdown", "pygments", "jsonschema"])
     print("Dependencies installed successfully.")
 
 from blockdoc import Block, BlockDocDocument
@@ -123,11 +121,7 @@ print(html)""",
     )
 
     # Add a quote
-    blog_post.add_block(
-        Block.text(
-            "quote-intro", "BlockDoc was designed with a specific philosophy in mind:"
-        )
-    )
+    blog_post.add_block(Block.text("quote-intro", "BlockDoc was designed with a specific philosophy in mind:"))
 
     quote_block = Block(
         {
@@ -211,9 +205,7 @@ def main():
     )
 
     print("Saving updated document...")
-    with open(
-        os.path.join(output_dir, "blog-post-updated.json"), "w", encoding="utf-8"
-    ) as f:
+    with open(os.path.join(output_dir, "blog-post-updated.json"), "w", encoding="utf-8") as f:
         f.write(blog_post.to_json())
 
     print("Example complete! Output files saved to:", output_dir)

--- a/examples/llm-integration/llm_content_generator.py
+++ b/examples/llm-integration/llm_content_generator.py
@@ -325,9 +325,7 @@ def main():
     """
     Main function to run the example
     """
-    parser = argparse.ArgumentParser(
-        description="Generate content with LLMs and BlockDoc"
-    )
+    parser = argparse.ArgumentParser(description="Generate content with LLMs and BlockDoc")
     parser.add_argument(
         "--title",
         default="BlockDoc: A Modern Approach to Structured Content",
@@ -375,9 +373,7 @@ def main():
         print(f"Updated document saved to {updated_path}")
 
         # Also save HTML for preview
-        html_path = os.path.join(
-            args.output_dir, f"updated_{os.path.splitext(output_file)[0]}.html"
-        )
+        html_path = os.path.join(args.output_dir, f"updated_{os.path.splitext(output_file)[0]}.html")
         with open(html_path, "w", encoding="utf-8") as f:
             f.write(document.render_to_html())
         print(f"HTML preview saved to {html_path}")

--- a/examples/markdown_conversion_example.py
+++ b/examples/markdown_conversion_example.py
@@ -104,25 +104,19 @@ def main():
 
     # Save the document as JSON
     print("Saving document as JSON...")
-    with open(
-        os.path.join(output_dir, "markdown-converted.json"), "w", encoding="utf-8"
-    ) as f:
+    with open(os.path.join(output_dir, "markdown-converted.json"), "w", encoding="utf-8") as f:
         f.write(doc.to_json(indent=2))
 
     # Render back to Markdown
     print("Rendering back to Markdown...")
     markdown = doc.render_to_markdown()
-    with open(
-        os.path.join(output_dir, "markdown-roundtrip.md"), "w", encoding="utf-8"
-    ) as f:
+    with open(os.path.join(output_dir, "markdown-roundtrip.md"), "w", encoding="utf-8") as f:
         f.write(markdown)
 
     # Render to HTML
     print("Rendering to HTML...")
     html = doc.render_to_html()
-    with open(
-        os.path.join(output_dir, "markdown-converted.html"), "w", encoding="utf-8"
-    ) as f:
+    with open(os.path.join(output_dir, "markdown-converted.html"), "w", encoding="utf-8") as f:
         f.write(html)
 
     # Display block structure

--- a/examples/markdown_conversion_example.py
+++ b/examples/markdown_conversion_example.py
@@ -1,0 +1,134 @@
+"""
+BlockDoc Markdown Conversion Example
+
+This example demonstrates converting Markdown to BlockDoc format
+"""
+
+import os
+import sys
+from datetime import datetime
+
+# Add the parent directory to sys.path to import blockdoc
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from blockdoc import markdown_to_blockdoc
+
+# Sample markdown content
+SAMPLE_MARKDOWN = """# Markdown to BlockDoc Conversion
+
+This is a demonstration of converting **Markdown** content to BlockDoc format.
+
+## Key Features
+
+BlockDoc makes it easy to work with structured content:
+
+- Maintains semantic structure
+- Preserves formatting
+- Creates meaningful block IDs
+
+### Code Examples
+
+Here's an example of Python code:
+
+```python
+from blockdoc import markdown_to_blockdoc
+
+# Convert markdown to BlockDoc
+doc = markdown_to_blockdoc(markdown_text)
+
+# Export as JSON
+json_str = doc.to_json()
+print(json_str)
+```
+
+## Images and Media
+
+Images are properly converted:
+
+![Example image](https://placehold.co/600x400?text=Example+Image) Example image caption
+
+## Block Quotes
+
+BlockDoc handles various content types:
+
+> This is a block quote that will be properly converted
+> to a BlockDoc quote block, preserving its formatting
+> and presentation.
+> — Attribution Source
+
+---
+
+## Lists
+
+1. Ordered lists work great
+2. With multiple items
+3. Preserving the numbering
+
+* Unordered lists too
+* With proper nesting
+* And formatting
+
+## The End
+
+This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving
+the document structure while enabling all the benefits of block-based content.
+"""
+
+
+def main():
+    """
+    Main function to run the example
+    """
+    print("Converting Markdown to BlockDoc format...")
+    doc = markdown_to_blockdoc(
+        SAMPLE_MARKDOWN,
+        metadata={
+            "author": "BlockDoc Team",
+            "publishedDate": datetime.now().isoformat(),
+            "tags": ["markdown", "conversion", "example"],
+        },
+    )
+
+    # Validate the document against the schema
+    print("Validating against schema...")
+    try:
+        doc.validate()
+        print("✓ Document is valid")
+    except ValueError as e:
+        print(f"✗ Validation failed: {e}")
+        return
+
+    # Create output directory
+    output_dir = os.path.join(os.path.dirname(__file__), "output")
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Save the document as JSON
+    print("Saving document as JSON...")
+    with open(os.path.join(output_dir, "markdown-converted.json"), "w", encoding="utf-8") as f:
+        f.write(doc.to_json(indent=2))
+
+    # Render back to Markdown
+    print("Rendering back to Markdown...")
+    markdown = doc.render_to_markdown()
+    with open(os.path.join(output_dir, "markdown-roundtrip.md"), "w", encoding="utf-8") as f:
+        f.write(markdown)
+
+    # Render to HTML
+    print("Rendering to HTML...")
+    html = doc.render_to_html()
+    with open(os.path.join(output_dir, "markdown-converted.html"), "w", encoding="utf-8") as f:
+        f.write(html)
+
+    # Display block structure
+    print("\nDocument structure:")
+    for i, block in enumerate(doc.article["blocks"]):
+        print(f"{i+1}. Type: {block['type']}, ID: {block['id']}")
+
+    print("\nExample complete! Output files saved to:", output_dir)
+    print("• markdown-converted.json - The BlockDoc document in JSON format")
+    print("• markdown-roundtrip.md - The document rendered back to Markdown")
+    print("• markdown-converted.html - The document rendered to HTML")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/markdown_conversion_example.py
+++ b/examples/markdown_conversion_example.py
@@ -104,25 +104,31 @@ def main():
 
     # Save the document as JSON
     print("Saving document as JSON...")
-    with open(os.path.join(output_dir, "markdown-converted.json"), "w", encoding="utf-8") as f:
+    with open(
+        os.path.join(output_dir, "markdown-converted.json"), "w", encoding="utf-8"
+    ) as f:
         f.write(doc.to_json(indent=2))
 
     # Render back to Markdown
     print("Rendering back to Markdown...")
     markdown = doc.render_to_markdown()
-    with open(os.path.join(output_dir, "markdown-roundtrip.md"), "w", encoding="utf-8") as f:
+    with open(
+        os.path.join(output_dir, "markdown-roundtrip.md"), "w", encoding="utf-8"
+    ) as f:
         f.write(markdown)
 
     # Render to HTML
     print("Rendering to HTML...")
     html = doc.render_to_html()
-    with open(os.path.join(output_dir, "markdown-converted.html"), "w", encoding="utf-8") as f:
+    with open(
+        os.path.join(output_dir, "markdown-converted.html"), "w", encoding="utf-8"
+    ) as f:
         f.write(html)
 
     # Display block structure
     print("\nDocument structure:")
     for i, block in enumerate(doc.article["blocks"]):
-        print(f"{i+1}. Type: {block['type']}, ID: {block['id']}")
+        print(f"{i + 1}. Type: {block['type']}, ID: {block['id']}")
 
     print("\nExample complete! Output files saved to:", output_dir)
     print("• markdown-converted.json - The BlockDoc document in JSON format")

--- a/examples/output/markdown-converted.html
+++ b/examples/output/markdown-converted.html
@@ -1,0 +1,40 @@
+<article class="blockdoc-article">
+<h1 class="blockdoc-title">Markdown to BlockDoc Conversion</h1>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-6bde1965" data-block-type="text"><p>This is a demonstration of converting <strong>Markdown</strong> content to BlockDoc format.</p></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="key-features" data-block-type="heading"><h2>Key Features</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-5c1cd4c6" data-block-type="text"><p>BlockDoc makes it easy to work with structured content:</p></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="unordered-list-36e4adc8" data-block-type="list"><ul class="blockdoc-list blockdoc-list-unordered"><li>Maintains semantic structure</li><li>Preserves formatting</li><li>Creates meaningful block IDs</li></ul></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="code-examples" data-block-type="heading"><h3>Code Examples</h3></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-0c25e226" data-block-type="text"><p>Here's an example of Python code:</p></div>
+<div class="blockdoc-block blockdoc-code" data-block-id="code-python-ff977aa3" data-block-type="code">
+    <pre class="blockdoc-pre">
+      <code class="blockdoc-code language-python">
+<div class="highlight"><pre><span></span><span class="kn">from</span><span class="w"> </span><span class="nn">blockdoc</span><span class="w"> </span><span class="kn">import</span> <span class="n">markdown_to_blockdoc</span>
+
+<span class="c1"># Convert markdown to BlockDoc</span>
+<span class="n">doc</span> <span class="o">=</span> <span class="n">markdown_to_blockdoc</span><span class="p">(</span><span class="n">markdown_text</span><span class="p">)</span>
+
+<span class="c1"># Export as JSON</span>
+<span class="n">json_str</span> <span class="o">=</span> <span class="n">doc</span><span class="o">.</span><span class="n">to_json</span><span class="p">()</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">json_str</span><span class="p">)</span>
+</pre></div>
+
+      </code>
+    </pre>
+    </div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="images-and-media" data-block-type="heading"><h2>Images and Media</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-c3fdfd77" data-block-type="text"><p>Images are properly converted:</p></div>
+<div class="blockdoc-block blockdoc-image" data-block-id="image-101fc707" data-block-type="image"><figure class="blockdoc-figure"><img src="https://placehold.co/600x400?text=Example+Image" alt="Example image" class="blockdoc-image" /><figcaption class="blockdoc-caption">Example image caption</figcaption></figure></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="block-quotes" data-block-type="heading"><h2>Block Quotes</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-8a6ab0c7" data-block-type="text"><p>BlockDoc handles various content types:</p></div>
+<div class="blockdoc-block blockdoc-quote" data-block-id="quote-25f02b35" data-block-type="quote"><blockquote class="blockdoc-quote"><p>This is a block quote that will be properly converted
+to a BlockDoc quote block, preserving its formatting
+and presentation.</p></blockquote><cite class="blockdoc-attribution">Attribution Source</cite></div>
+<div class="blockdoc-block blockdoc-divider" data-block-id="divider-f94a9524" data-block-type="divider"><hr class="blockdoc-divider" /></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="lists" data-block-type="heading"><h2>Lists</h2></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="ordered-list-414f8890" data-block-type="list"><ol class="blockdoc-list blockdoc-list-ordered"><li>Ordered lists work great</li><li>With multiple items</li><li>Preserving the numbering</li></ol></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="unordered-list-d682e69f" data-block-type="list"><ul class="blockdoc-list blockdoc-list-unordered"><li>Unordered lists too</li><li>With proper nesting</li><li>And formatting</li></ul></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="the-end" data-block-type="heading"><h2>The End</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-78faa450" data-block-type="text"><p>This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving
+the document structure while enabling all the benefits of block-based content.</p></div>
+</article>

--- a/examples/output/markdown-converted.json
+++ b/examples/output/markdown-converted.json
@@ -1,0 +1,140 @@
+{
+  "article": {
+    "title": "Markdown to BlockDoc Conversion",
+    "metadata": {
+      "author": "BlockDoc Team",
+      "publishedDate": "2025-04-25T15:51:21.904700",
+      "tags": [
+        "markdown",
+        "conversion",
+        "example"
+      ]
+    },
+    "blocks": [
+      {
+        "id": "text-6bde1965",
+        "type": "text",
+        "content": "This is a demonstration of converting **Markdown** content to BlockDoc format."
+      },
+      {
+        "id": "key-features",
+        "type": "heading",
+        "content": "Key Features",
+        "level": 2
+      },
+      {
+        "id": "text-5c1cd4c6",
+        "type": "text",
+        "content": "BlockDoc makes it easy to work with structured content:"
+      },
+      {
+        "id": "unordered-list-36e4adc8",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Maintains semantic structure",
+          "Preserves formatting",
+          "Creates meaningful block IDs"
+        ],
+        "list_type": "unordered"
+      },
+      {
+        "id": "code-examples",
+        "type": "heading",
+        "content": "Code Examples",
+        "level": 3
+      },
+      {
+        "id": "text-0c25e226",
+        "type": "text",
+        "content": "Here's an example of Python code:"
+      },
+      {
+        "id": "code-python-ff977aa3",
+        "type": "code",
+        "content": "from blockdoc import markdown_to_blockdoc\n\n# Convert markdown to BlockDoc\ndoc = markdown_to_blockdoc(markdown_text)\n\n# Export as JSON\njson_str = doc.to_json()\nprint(json_str)",
+        "language": "python"
+      },
+      {
+        "id": "images-and-media",
+        "type": "heading",
+        "content": "Images and Media",
+        "level": 2
+      },
+      {
+        "id": "text-c3fdfd77",
+        "type": "text",
+        "content": "Images are properly converted:"
+      },
+      {
+        "id": "image-101fc707",
+        "type": "image",
+        "content": "",
+        "url": "https://placehold.co/600x400?text=Example+Image",
+        "alt": "Example image",
+        "caption": "Example image caption"
+      },
+      {
+        "id": "block-quotes",
+        "type": "heading",
+        "content": "Block Quotes",
+        "level": 2
+      },
+      {
+        "id": "text-8a6ab0c7",
+        "type": "text",
+        "content": "BlockDoc handles various content types:"
+      },
+      {
+        "id": "quote-25f02b35",
+        "type": "quote",
+        "content": "This is a block quote that will be properly converted\nto a BlockDoc quote block, preserving its formatting\nand presentation.",
+        "attribution": "Attribution Source"
+      },
+      {
+        "id": "divider-f94a9524",
+        "type": "divider",
+        "content": ""
+      },
+      {
+        "id": "lists",
+        "type": "heading",
+        "content": "Lists",
+        "level": 2
+      },
+      {
+        "id": "ordered-list-414f8890",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Ordered lists work great",
+          "With multiple items",
+          "Preserving the numbering"
+        ],
+        "list_type": "ordered"
+      },
+      {
+        "id": "unordered-list-d682e69f",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Unordered lists too",
+          "With proper nesting",
+          "And formatting"
+        ],
+        "list_type": "unordered"
+      },
+      {
+        "id": "the-end",
+        "type": "heading",
+        "content": "The End",
+        "level": 2
+      },
+      {
+        "id": "text-78faa450",
+        "type": "text",
+        "content": "This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving\nthe document structure while enabling all the benefits of block-based content."
+      }
+    ]
+  }
+}

--- a/examples/output/markdown-roundtrip.md
+++ b/examples/output/markdown-roundtrip.md
@@ -1,0 +1,64 @@
+# Markdown to BlockDoc Conversion
+
+> Author: BlockDoc Team
+> Published: Fri Apr 25 2025
+> Tags: markdown, conversion, example
+
+This is a demonstration of converting **Markdown** content to BlockDoc format.
+
+## Key Features
+
+BlockDoc makes it easy to work with structured content:
+
+- Maintains semantic structure
+- Preserves formatting
+- Creates meaningful block IDs
+
+### Code Examples
+
+Here's an example of Python code:
+
+```python
+from blockdoc import markdown_to_blockdoc
+
+# Convert markdown to BlockDoc
+doc = markdown_to_blockdoc(markdown_text)
+
+# Export as JSON
+json_str = doc.to_json()
+print(json_str)
+```
+
+## Images and Media
+
+Images are properly converted:
+
+![Example image](https://placehold.co/600x400?text=Example+Image)
+*Example image caption*
+
+## Block Quotes
+
+BlockDoc handles various content types:
+
+> This is a block quote that will be properly converted
+> to a BlockDoc quote block, preserving its formatting
+> and presentation.
+>
+> — Attribution Source
+
+---
+
+## Lists
+
+1. Ordered lists work great
+2. With multiple items
+3. Preserving the numbering
+
+- Unordered lists too
+- With proper nesting
+- And formatting
+
+## The End
+
+This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving
+the document structure while enabling all the benefits of block-based content.

--- a/examples/simple-blog/blog_generator.py
+++ b/examples/simple-blog/blog_generator.py
@@ -55,11 +55,7 @@ def create_blog_post(title, author, content_json=None):
                 blog_post.add_block(Block.text(block_id, item.get("content", "")))
 
             elif block_type == "heading":
-                blog_post.add_block(
-                    Block.heading(
-                        block_id, item.get("level", 2), item.get("content", "")
-                    )
-                )
+                blog_post.add_block(Block.heading(block_id, item.get("level", 2), item.get("content", "")))
 
             elif block_type == "image":
                 blog_post.add_block(
@@ -72,11 +68,7 @@ def create_blog_post(title, author, content_json=None):
                 )
 
             elif block_type == "code":
-                blog_post.add_block(
-                    Block.code(
-                        block_id, item.get("language", "text"), item.get("content", "")
-                    )
-                )
+                blog_post.add_block(Block.code(block_id, item.get("language", "text"), item.get("content", "")))
 
             elif block_type == "list":
                 blog_post.add_block(
@@ -88,11 +80,7 @@ def create_blog_post(title, author, content_json=None):
                 )
 
             elif block_type == "quote":
-                blog_post.add_block(
-                    Block.quote(
-                        block_id, item.get("content", ""), item.get("attribution")
-                    )
-                )
+                blog_post.add_block(Block.quote(block_id, item.get("content", ""), item.get("attribution")))
 
             elif block_type == "divider":
                 blog_post.add_block(Block.divider(block_id))
@@ -178,14 +166,10 @@ def main():
     Main function to run the blog generator
     """
     parser = argparse.ArgumentParser(description="Generate a blog post using BlockDoc")
-    parser.add_argument(
-        "--title", default="BlockDoc Blog Example", help="Blog post title"
-    )
+    parser.add_argument("--title", default="BlockDoc Blog Example", help="Blog post title")
     parser.add_argument("--author", default="BlockDoc Team", help="Blog post author")
     parser.add_argument("--content", help="Path to JSON file with content structure")
-    parser.add_argument(
-        "--output-dir", default="./output", help="Output directory for generated files"
-    )
+    parser.add_argument("--output-dir", default="./output", help="Output directory for generated files")
 
     args = parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ exclude = [
 [tool.ruff.lint]
 # Enable pycodestyle (E), Pyflakes (F), isort (I), and more
 select = ["E", "F", "I", "W", "N", "UP", "B", "C4", "SIM", "ERA"]
-ignore = []
+ignore = ["E203"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["blockdoc"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 target-version = "py37"
-line-length = 88
+line-length = 120
 exclude = [
     ".git",
     ".ruff_cache",
@@ -16,7 +16,14 @@ exclude = [
 [tool.ruff.lint]
 # Enable pycodestyle (E), Pyflakes (F), isort (I), and more
 select = ["E", "F", "I", "W", "N", "UP", "B", "C4", "SIM", "ERA"]
-ignore = ["E203"]
+ignore = [
+    "B904",
+    "E203",
+    "E501",
+    "E741",
+    "ERA001",
+    "F401",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["blockdoc"]
@@ -32,7 +39,7 @@ python_files = "test_*.py"
 addopts = "--cov=blockdoc"
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -5942,7 +5942,7 @@ python_files = "test_*.py"
 addopts = "--cov=blockdoc"
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -1,4 +1,5 @@
 This file is a merged representation of the entire codebase, combined into a single document by Repomix.
+The content has been processed where comments have been removed, empty lines have been removed, content has been compressed (code blocks are separated by ⋮---- delimiter).
 
 <file_summary>
 This section contains a summary of this file.
@@ -33,6 +34,9 @@ The content is organized as follows:
 - Binary files are not included in this packed representation. Please refer to the Repository Structure section for a complete list of file paths, including binary files
 - Files matching patterns in .gitignore are excluded
 - Files matching default ignore patterns are excluded
+- Code comments have been removed from supported file types
+- Empty lines have been removed from all files
+- Content has been compressed - code blocks are separated by ⋮---- delimiter
 - Files are sorted by Git change count (files with more changes are at the bottom)
 </notes>
 
@@ -43,6 +47,9 @@ The content is organized as follows:
 </file_summary>
 
 <directory_structure>
+.claude/
+  commands/
+    add-to-changelog.md
 .github/
   workflows/
     python-lint.yml
@@ -50,6 +57,9 @@ The content is organized as follows:
 blockdoc/
   api/
     __init__.py
+  conversions/
+    __init__.py
+    markdown.py
   core/
     __init__.py
     block.py
@@ -86,1193 +96,142 @@ examples/
   llm-integration/
     llm_content_generator.py
     README.md
+  output/
+    markdown-converted.html
+    markdown-converted.json
+    markdown-roundtrip.md
   simple-blog/
     blog_generator.py
     README.md
     sample_content.json
   basic_example.py
+  markdown_conversion_example.py
   README.md
+scripts/
+  format.sh
+  lint.sh
 tests/
+  conversions/
+    test_markdown.py
   core/
     __init__.py
     test_block.py
     test_document.py
   __init__.py
 .gitignore
+.pre-commit-config.yaml
+.repomixignore
+CHANGELOG.md
+CLAUDE.md
 CONTRIBUTING.md
 LICENSE
 MANIFEST.in
 pyproject.toml
 README.md
+repomix.config.json
 setup.py
 </directory_structure>
 
 <files>
 This section contains the contents of the repository's files.
 
-<file path="blockdoc/api/__init__.py">
-# API module for BlockDoc
+<file path=".repomixignore">
+# Add patterns to ignore here, one per line
+# Example:
+# *.log
+# tmp/
 </file>
 
-<file path="blockdoc/core/__init__.py">
-# Core module for BlockDoc
-</file>
-
-<file path="blockdoc/core/block.py">
-"""
-BlockDoc Block
-
-Represents a single content block within a BlockDoc document
-"""
-
-# Define allowed block types
-ALLOWED_TYPES = [
-    'text',
-    'heading',
-    'image',
-    'code',
-    'list',
-    'quote',
-    'embed',
-    'divider',
-]
-
-# Define type-specific required properties
-TYPE_REQUIREMENTS = {
-    'heading': ['level'],
-    'code': ['language'],
-    'image': ['url', 'alt'],
-    'list': ['items', 'list_type'],
+<file path="repomix.config.json">
+{
+  "output": {
+    "filePath": "repomix-output.xml",
+    "style": "xml",
+    "parsableStyle": false,
+    "fileSummary": true,
+    "directoryStructure": true,
+    "removeComments": true,
+    "removeEmptyLines": true,
+    "compress": true,
+    "topFilesLength": 5,
+    "showLineNumbers": false,
+    "copyToClipboard": false,
+    "git": {
+      "sortByChanges": true,
+      "sortByChangesMaxCommits": 100
+    }
+  },
+  "include": [],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": []
+  },
+  "security": {
+    "enableSecurityCheck": true
+  },
+  "tokenCount": {
+    "encoding": "o200k_base"
+  }
 }
-
-
-class Block:
-    """
-    Create a new block
-    """
-    def __init__(self, data):
-        """
-        Initialize a new Block
-        
-        Args:
-            data (dict): Block data
-        """
-        if not data.get('id'):
-            raise ValueError('Block ID is required')
-        
-        if not data.get('type') or data.get('type') not in ALLOWED_TYPES:
-            raise ValueError(
-                f"Invalid block type: {data.get('type')}. "
-                f"Allowed types are: {', '.join(ALLOWED_TYPES)}"
-            )
-        
-        # Basic properties all blocks have
-        self.id = data['id']
-        self.type = data['type']
-        self.content = data.get('content', '')
-        
-        # Check type-specific required properties
-        required_props = TYPE_REQUIREMENTS.get(self.type, [])
-        for prop in required_props:
-            # Convert camelCase to snake_case for Python
-            python_prop = prop
-            if prop == 'listType':
-                python_prop = 'list_type'
-            
-            if python_prop not in data and prop not in data:
-                raise ValueError(
-                    f'Block of type "{self.type}" requires property "{prop}"'
-                )
-            
-            # Check both formats and prefer snake_case
-            if python_prop in data:
-                setattr(self, python_prop, data[python_prop])
-            else:
-                setattr(self, python_prop, data[prop])
-        
-        # Copy any additional properties
-        for key, value in data.items():
-            if key not in ['id', 'type', 'content'] and not hasattr(self, key):
-                setattr(self, key, value)
-    
-    def update(self, updates):
-        """
-        Update block properties
-        
-        Args:
-            updates (dict): Properties to update
-            
-        Returns:
-            Block: Updated block instance
-        """
-        # Cannot change block type or ID
-        updates_copy = updates.copy()
-        updates_copy.pop('id', None)
-        updates_copy.pop('type', None)
-        
-        # Apply updates
-        for key, value in updates_copy.items():
-            setattr(self, key, value)
-        
-        return self
-    
-    def to_dict(self):
-        """
-        Convert block to dictionary
-        
-        Returns:
-            dict: Block as dictionary
-        """
-        result = {
-            'id': self.id,
-            'type': self.type,
-            'content': self.content,
-        }
-        
-        # Add type-specific properties
-        for key, value in self.__dict__.items():
-            if key not in ['id', 'type', 'content']:
-                result[key] = value
-        
-        return result
-    
-    # Factory methods for creating common block types
-    
-    @classmethod
-    def text(cls, id, content):
-        """
-        Create a text block
-        
-        Args:
-            id (str): Block ID
-            content (str): Markdown content
-            
-        Returns:
-            Block: New block instance
-        """
-        return cls({
-            'id': id,
-            'type': 'text',
-            'content': content,
-        })
-    
-    @classmethod
-    def heading(cls, id, level, content):
-        """
-        Create a heading block
-        
-        Args:
-            id (str): Block ID
-            level (int): Heading level (1-6)
-            content (str): Heading text
-            
-        Returns:
-            Block: New block instance
-        """
-        return cls({
-            'id': id,
-            'type': 'heading',
-            'level': level,
-            'content': content,
-        })
-    
-    @classmethod
-    def image(cls, id, url, alt, caption=None):
-        """
-        Create an image block
-        
-        Args:
-            id (str): Block ID
-            url (str): Image URL
-            alt (str): Alt text
-            caption (str, optional): Optional caption
-            
-        Returns:
-            Block: New block instance
-        """
-        data = {
-            'id': id,
-            'type': 'image',
-            'content': '',
-            'url': url,
-            'alt': alt,
-        }
-        
-        if caption:
-            data['caption'] = caption
-        
-        return cls(data)
-    
-    @classmethod
-    def code(cls, id, language, content):
-        """
-        Create a code block
-        
-        Args:
-            id (str): Block ID
-            language (str): Programming language
-            content (str): Code content
-            
-        Returns:
-            Block: New block instance
-        """
-        return cls({
-            'id': id,
-            'type': 'code',
-            'language': language,
-            'content': content,
-        })
-    
-    @classmethod
-    def list(cls, id, items, list_type='unordered'):
-        """
-        Create a list block
-        
-        Args:
-            id (str): Block ID
-            items (list): List items
-            list_type (str, optional): List type (ordered or unordered)
-            
-        Returns:
-            Block: New block instance
-        """
-        return cls({
-            'id': id,
-            'type': 'list',
-            'content': '',
-            'items': items,
-            'list_type': list_type,
-        })
-    
-    @classmethod
-    def quote(cls, id, content, attribution=None):
-        """
-        Create a quote block
-        
-        Args:
-            id (str): Block ID
-            content (str): Quote content
-            attribution (str, optional): Source attribution
-            
-        Returns:
-            Block: New block instance
-        """
-        data = {
-            'id': id,
-            'type': 'quote',
-            'content': content,
-        }
-        
-        if attribution:
-            data['attribution'] = attribution
-        
-        return cls(data)
-    
-    @classmethod
-    def embed(cls, id, url, embed_type, caption=None):
-        """
-        Create an embed block
-        
-        Args:
-            id (str): Block ID
-            url (str): URL of embedded content
-            embed_type (str): Type of embed (youtube, twitter, etc)
-            caption (str, optional): Optional caption
-            
-        Returns:
-            Block: New block instance
-        """
-        data = {
-            'id': id,
-            'type': 'embed',
-            'content': '',
-            'url': url,
-            'embed_type': embed_type,
-        }
-        
-        if caption:
-            data['caption'] = caption
-        
-        return cls(data)
-    
-    @classmethod
-    def divider(cls, id):
-        """
-        Create a divider block
-        
-        Args:
-            id (str): Block ID
-            
-        Returns:
-            Block: New block instance
-        """
-        return cls({
-            'id': id,
-            'type': 'divider',
-            'content': '',
-        })
 </file>
 
-<file path="blockdoc/core/document.py">
-"""
-BlockDoc Document
+<file path=".claude/commands/add-to-changelog.md">
+# Update Changelog
 
-Core class for creating, manipulating and rendering BlockDoc documents
-"""
+This command adds a new entry to the project's CHANGELOG.md file.
 
-import json
-import jsonschema
-from blockdoc.core.block import Block
-from blockdoc.schema.loader import schema
-from blockdoc.renderers.html import render_to_html
-from blockdoc.renderers.markdown import render_to_markdown
+## Usage
 
+```
+/add-to-changelog <version> <change_type> <message>
+```
 
-class BlockDocDocument:
-    """
-    Create a new BlockDoc document
-    """
-    def __init__(self, options):
-        """
-        Initialize a new BlockDoc document
-        
-        Args:
-            options (dict): Document initialization options
-                - title (str): Document title
-                - metadata (dict, optional): Optional document metadata
-                - blocks (list, optional): Initial blocks to add
-        """
-        title = options.get('title')
-        metadata = options.get('metadata', {})
-        blocks = options.get('blocks', [])
-        
-        if not title:
-            raise ValueError("Document title is required")
-        
-        self.article = {
-            'title': title,
-            'metadata': metadata,
-            'blocks': [],
-        }
-        
-        # Add initial blocks if provided
-        if blocks and isinstance(blocks, list):
-            for block_data in blocks:
-                self.add_block(block_data)
-    
-    def validate(self):
-        """
-        Validate the document against the BlockDoc schema
-        
-        Returns:
-            bool: True if valid
-            
-        Raises:
-            ValueError: If validation fails
-        """
-        try:
-            jsonschema.validate(instance={'article': self.article}, schema=schema)
-            return True
-        except jsonschema.exceptions.ValidationError as e:
-            raise ValueError(f"Invalid BlockDoc document: {str(e)}")
-    
-    def add_block(self, block_data):
-        """
-        Add a block to the document
-        
-        Args:
-            block_data (dict or Block): Block data or Block instance
-            
-        Returns:
-            Block: The created block
-            
-        Raises:
-            ValueError: If block with the same ID already exists
-        """
-        # If it's already a Block instance, convert to dict
-        if isinstance(block_data, Block):
-            block_data = block_data.to_dict()
-        
-        # Check if ID already exists
-        if self.get_block(block_data['id']):
-            raise ValueError(f"Block with ID '{block_data['id']}' already exists")
-        
-        block = Block(block_data)
-        self.article['blocks'].append(block.to_dict())
-        return block
-    
-    def insert_block(self, block_data, position):
-        """
-        Insert a block at a specific position
-        
-        Args:
-            block_data (dict or Block): Block data or Block instance
-            position (int): Position to insert at
-            
-        Returns:
-            Block: The created block
-            
-        Raises:
-            ValueError: If block with the same ID already exists
-        """
-        # If it's already a Block instance, convert to dict
-        if isinstance(block_data, Block):
-            block_data = block_data.to_dict()
-        
-        # Check if ID already exists
-        if self.get_block(block_data['id']):
-            raise ValueError(f"Block with ID '{block_data['id']}' already exists")
-        
-        block = Block(block_data)
-        self.article['blocks'].insert(position, block.to_dict())
-        return block
-    
-    def get_block(self, id):
-        """
-        Get a block by ID
-        
-        Args:
-            id (str): Block ID
-            
-        Returns:
-            dict or None: The block or None if not found
-        """
-        for block in self.article['blocks']:
-            if block['id'] == id:
-                return block
-        return None
-    
-    def update_block(self, id, updates):
-        """
-        Update a block by ID
-        
-        Args:
-            id (str): Block ID
-            updates (dict): Properties to update
-            
-        Returns:
-            dict: The updated block
-            
-        Raises:
-            ValueError: If block with the ID doesn't exist
-        """
-        index = -1
-        for i, block in enumerate(self.article['blocks']):
-            if block['id'] == id:
-                index = i
-                break
-        
-        if index == -1:
-            raise ValueError(f"Block with ID '{id}' not found")
-        
-        # Create a new block with the updates
-        current_block = self.article['blocks'][index]
-        updated_data = {**current_block, **updates}
-        
-        # Validate the updated block
-        block = Block(updated_data)
-        
-        # Update the block in the document
-        self.article['blocks'][index] = block.to_dict()
-        
-        return self.article['blocks'][index]
-    
-    def remove_block(self, id):
-        """
-        Remove a block by ID
-        
-        Args:
-            id (str): Block ID
-            
-        Returns:
-            bool: True if removed, False if not found
-        """
-        index = -1
-        for i, block in enumerate(self.article['blocks']):
-            if block['id'] == id:
-                index = i
-                break
-        
-        if index == -1:
-            return False
-        
-        self.article['blocks'].pop(index)
-        return True
-    
-    def move_block(self, id, new_position):
-        """
-        Move a block to a new position
-        
-        Args:
-            id (str): Block ID
-            new_position (int): New position
-            
-        Returns:
-            bool: True if moved, False if not found
-            
-        Raises:
-            ValueError: If new_position is invalid
-        """
-        index = -1
-        for i, block in enumerate(self.article['blocks']):
-            if block['id'] == id:
-                index = i
-                break
-        
-        if index == -1:
-            return False
-        
-        if new_position < 0 or new_position >= len(self.article['blocks']):
-            raise ValueError(f"Invalid position: {new_position}")
-        
-        # Remove the block from its current position
-        block = self.article['blocks'].pop(index)
-        
-        # Insert it at the new position
-        self.article['blocks'].insert(new_position, block)
-        
-        return True
-    
-    def render_to_html(self):
-        """
-        Render the document to HTML
-        
-        Returns:
-            str: HTML representation
-        """
-        return render_to_html(self.article)
-    
-    def render_to_markdown(self):
-        """
-        Render the document to Markdown
-        
-        Returns:
-            str: Markdown representation
-        """
-        return render_to_markdown(self.article)
-    
-    def to_dict(self):
-        """
-        Export the document as a dictionary
-        
-        Returns:
-            dict: Document as dictionary
-        """
-        return {'article': self.article}
-    
-    def to_json(self, indent=2):
-        """
-        Export the document as a JSON string
-        
-        Args:
-            indent (int, optional): JSON indentation level
-            
-        Returns:
-            str: Document as JSON string
-        """
-        return json.dumps(self.to_dict(), indent=indent)
-    
-    @classmethod
-    def from_dict(cls, data):
-        """
-        Create a BlockDoc document from a dictionary
-        
-        Args:
-            data (dict): Document data
-            
-        Returns:
-            BlockDocDocument: New document instance
-            
-        Raises:
-            ValueError: If data is invalid
-        """
-        if not data.get('article'):
-            raise ValueError('Invalid BlockDoc document: missing article property')
-        
-        article = data['article']
-        
-        return cls({
-            'title': article.get('title'),
-            'metadata': article.get('metadata', {}),
-            'blocks': article.get('blocks', []),
-        })
-    
-    @classmethod
-    def from_json(cls, json_str):
-        """
-        Create a BlockDoc document from a JSON string
-        
-        Args:
-            json_str (str): JSON string
-            
-        Returns:
-            BlockDocDocument: New document instance
-            
-        Raises:
-            ValueError: If JSON is invalid
-        """
-        try:
-            data = json.loads(json_str)
-            return cls.from_dict(data)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON: {str(e)}")
+Where:
+- `<version>` is the version number (e.g., "1.1.0")
+- `<change_type>` is one of: "added", "changed", "deprecated", "removed", "fixed", "security"
+- `<message>` is the description of the change
+
+## Examples
+
+```
+/add-to-changelog 1.1.0 added "New markdown to BlockDoc conversion feature"
+```
+
+```
+/add-to-changelog 1.0.2 fixed "Bug in HTML renderer causing incorrect output"
+```
+
+## Description
+
+This command will:
+
+1. Check if a CHANGELOG.md file exists and create one if needed
+2. Look for an existing section for the specified version
+   - If found, add the new entry under the appropriate change type section
+   - If not found, create a new version section with today's date
+3. Format the entry according to Keep a Changelog conventions
+4. Commit the changes if requested
+
+The CHANGELOG follows the [Keep a Changelog](https://keepachangelog.com/) format and [Semantic Versioning](https://semver.org/).
+
+## Implementation
+
+The command should:
+
+1. Parse the arguments to extract version, change type, and message
+2. Read the existing CHANGELOG.md file if it exists
+3. If the file doesn't exist, create a new one with standard header
+4. Check if the version section already exists
+5. Add the new entry in the appropriate section
+6. Write the updated content back to the file
+7. Suggest committing the changes
+
+Remember to update the package version in `__init__.py` and `setup.py` if this is a new version.
 </file>
 
-<file path="blockdoc/renderers/__init__.py">
-# Renderers module for BlockDoc
-</file>
-
-<file path="blockdoc/renderers/html.py">
-"""
-BlockDoc HTML Renderer
-
-Converts BlockDoc documents to HTML
-"""
-
-import re
-from markdown import markdown
-from pygments import highlight
-from pygments.lexers import get_lexer_by_name, guess_lexer
-from pygments.formatters import HtmlFormatter
-from pygments.util import ClassNotFound
-from blockdoc.utils.sanitize import sanitize_html, sanitize_url
-
-
-def render_to_html(article):
-    """
-    Render a BlockDoc document to HTML
-    
-    Args:
-        article (dict): The article object from a BlockDoc document
-        
-    Returns:
-        str: HTML representation
-    """
-    if not article or 'blocks' not in article or not isinstance(article['blocks'], list):
-        raise ValueError('Invalid article structure')
-    
-    html = [
-        '<article class="blockdoc-article">',
-        f'<h1 class="blockdoc-title">{sanitize_html(article["title"])}</h1>',
-    ]
-    
-    # Render each block
-    for block in article['blocks']:
-        html.append(render_block(block))
-    
-    html.append('</article>')
-    
-    return '\n'.join(html)
-
-
-def render_block(block):
-    """
-    Render a single block to HTML
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation of the block
-    """
-    block_id = block.get('id', '')
-    block_type = block.get('type', '')
-    
-    # Wrapper with block ID and type as data attributes
-    open_wrapper = f'<div class="blockdoc-block blockdoc-{block_type}" data-block-id="{block_id}" data-block-type="{block_type}">'
-    close_wrapper = '</div>'
-    
-    if block_type == 'text':
-        content = render_text_block(block)
-    elif block_type == 'heading':
-        content = render_heading_block(block)
-    elif block_type == 'image':
-        content = render_image_block(block)
-    elif block_type == 'code':
-        content = render_code_block(block)
-    elif block_type == 'list':
-        content = render_list_block(block)
-    elif block_type == 'quote':
-        content = render_quote_block(block)
-    elif block_type == 'embed':
-        content = render_embed_block(block)
-    elif block_type == 'divider':
-        content = render_divider_block()
-    else:
-        content = f'<p>Unknown block type: {block_type}</p>'
-    
-    return f'{open_wrapper}{content}{close_wrapper}'
-
-
-def render_text_block(block):
-    """
-    Render a text block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    # Use markdown to convert markdown to HTML
-    return markdown(block.get('content', ''))
-
-
-def render_heading_block(block):
-    """
-    Render a heading block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    level = block.get('level', 2)
-    content = block.get('content', '')
-    
-    # Ensure level is between 1-6
-    valid_level = min(max(int(level), 1), 6)
-    
-    return f'<h{valid_level}>{sanitize_html(content)}</h{valid_level}>'
-
-
-def render_image_block(block):
-    """
-    Render an image block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    url = sanitize_url(block.get('url', ''))
-    alt = sanitize_html(block.get('alt', ''))
-    caption = block.get('caption')
-    
-    img_html = f'<img src="{url}" alt="{alt}" class="blockdoc-image" />'
-    
-    if caption:
-        img_html += f'<figcaption class="blockdoc-caption">{sanitize_html(caption)}</figcaption>'
-        return f'<figure class="blockdoc-figure">{img_html}</figure>'
-    
-    return img_html
-
-
-def render_code_block(block):
-    """
-    Render a code block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    language = block.get('language', '')
-    content = block.get('content', '')
-    
-    # Use pygments for syntax highlighting
-    try:
-        if language and language != 'plain':
-            lexer = get_lexer_by_name(language)
-        else:
-            lexer = guess_lexer(content)
-        
-        highlighted_code = highlight(content, lexer, HtmlFormatter())
-    except (ClassNotFound, Exception):
-        highlighted_code = sanitize_html(content)
-    
-    return f"""
-    <pre class="blockdoc-pre">
-      <code class="blockdoc-code {f'language-{language}' if language else ''}">
-{highlighted_code}
-      </code>
-    </pre>
-    """
-
-
-def render_list_block(block):
-    """
-    Render a list block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    items = block.get('items', [])
-    # Support both snake_case (Python style) and camelCase (JS style)
-    list_type = block.get('list_type', block.get('listType', 'unordered'))
-    
-    if not items or not isinstance(items, list):
-        return '<p>Invalid list items</p>'
-    
-    tag = 'ol' if list_type == 'ordered' else 'ul'
-    
-    items_html = []
-    for item in items:
-        rendered_item = markdown(item)
-        # Remove paragraph tags that markdown adds by default
-        rendered_item = rendered_item.replace('<p>', '').replace('</p>', '')
-        items_html.append(f'<li>{rendered_item}</li>')
-    
-    return f'<{tag} class="blockdoc-list blockdoc-list-{list_type}">{"".join(items_html)}</{tag}>'
-
-
-def render_quote_block(block):
-    """
-    Render a quote block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    content = block.get('content', '')
-    attribution = block.get('attribution')
-    
-    html = f'<blockquote class="blockdoc-quote">{markdown(content)}</blockquote>'
-    
-    if attribution:
-        html += f'<cite class="blockdoc-attribution">{sanitize_html(attribution)}</cite>'
-    
-    return html
-
-
-def render_embed_block(block):
-    """
-    Render an embed block
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: HTML representation
-    """
-    url = sanitize_url(block.get('url', ''))
-    caption = block.get('caption')
-    # Support both snake_case (Python style) and camelCase (JS style)
-    embed_type = block.get('embed_type', block.get('embedType', 'generic'))
-    
-    if embed_type == 'youtube':
-        # Extract YouTube video ID
-        video_id = extract_youtube_id(url)
-        if video_id:
-            embed_html = f"""
-            <div class="blockdoc-embed-container">
-              <iframe 
-                width="560" 
-                height="315" 
-                src="https://www.youtube.com/embed/{video_id}" 
-                frameborder="0" 
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-                allowfullscreen>
-              </iframe>
-            </div>
-            """
-        else:
-            embed_html = '<p>Invalid YouTube URL</p>'
-    elif embed_type == 'twitter':
-        embed_html = f"""
-        <div class="blockdoc-embed blockdoc-twitter">
-          <blockquote class="twitter-tweet">
-            <a href="{url}"></a>
-          </blockquote>
-          <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        </div>
-        """
-    else:
-        # Generic embed with iframe
-        embed_html = f"""
-        <div class="blockdoc-embed">
-          <iframe 
-            src="{url}" 
-            frameborder="0" 
-            width="100%" 
-            height="400"
-            allowfullscreen>
-          </iframe>
-        </div>
-        """
-    
-    if caption:
-        embed_html += f'<figcaption class="blockdoc-caption">{sanitize_html(caption)}</figcaption>'
-        return f'<figure class="blockdoc-figure">{embed_html}</figure>'
-    
-    return embed_html
-
-
-def render_divider_block():
-    """
-    Render a divider block
-    
-    Returns:
-        str: HTML representation
-    """
-    return '<hr class="blockdoc-divider" />'
-
-
-def extract_youtube_id(url):
-    """
-    Extract YouTube video ID from URL
-    
-    Args:
-        url (str): YouTube URL
-        
-    Returns:
-        str or None: YouTube video ID or None if invalid
-    """
-    # Check for youtu.be format
-    youtu_be_match = re.match(r'https?://youtu\.be/([a-zA-Z0-9_-]+)', url)
-    if youtu_be_match:
-        return youtu_be_match.group(1)
-    
-    # Check for youtube.com format
-    youtube_match = re.match(r'https?://(?:www\.)?youtube\.com/watch\?v=([a-zA-Z0-9_-]+)', url)
-    if youtube_match:
-        return youtube_match.group(1)
-    
-    return None
-</file>
-
-<file path="blockdoc/renderers/markdown.py">
-"""
-BlockDoc Markdown Renderer
-
-Converts BlockDoc documents to Markdown
-"""
-
-from datetime import datetime
-
-
-def render_to_markdown(article):
-    """
-    Render a BlockDoc document to Markdown
-    
-    Args:
-        article (dict): The article object from a BlockDoc document
-        
-    Returns:
-        str: Markdown representation
-    """
-    if not article or 'blocks' not in article or not isinstance(article['blocks'], list):
-        raise ValueError('Invalid article structure')
-    
-    markdown = [
-        f"# {article['title']}",
-        ''
-    ]
-    
-    # Add metadata if present
-    if article.get('metadata'):
-        metadata = article['metadata']
-        
-        if metadata.get('author'):
-            markdown.append(f"> Author: {metadata['author']}")
-        
-        if metadata.get('publishedDate'):
-            try:
-                date = datetime.fromisoformat(metadata['publishedDate'].replace('Z', '+00:00'))
-                markdown.append(f"> Published: {date.strftime('%a %b %d %Y')}")
-            except (ValueError, AttributeError):
-                # If date parsing fails, just use the raw value
-                markdown.append(f"> Published: {metadata['publishedDate']}")
-        
-        if metadata.get('tags') and isinstance(metadata['tags'], list) and metadata['tags']:
-            markdown.append(f"> Tags: {', '.join(metadata['tags'])}")
-        
-        markdown.append('')
-    
-    # Render each block
-    for block in article['blocks']:
-        markdown.append(render_block_to_markdown(block))
-        markdown.append('')  # Add a blank line after each block
-    
-    return '\n'.join(markdown)
-
-
-def render_block_to_markdown(block):
-    """
-    Render a single block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation of the block
-    """
-    block_type = block.get('type', '')
-    
-    if block_type == 'text':
-        return render_text_block_to_markdown(block)
-    elif block_type == 'heading':
-        return render_heading_block_to_markdown(block)
-    elif block_type == 'image':
-        return render_image_block_to_markdown(block)
-    elif block_type == 'code':
-        return render_code_block_to_markdown(block)
-    elif block_type == 'list':
-        return render_list_block_to_markdown(block)
-    elif block_type == 'quote':
-        return render_quote_block_to_markdown(block)
-    elif block_type == 'embed':
-        return render_embed_block_to_markdown(block)
-    elif block_type == 'divider':
-        return '---'
-    else:
-        return f'[Unknown block type: {block_type}]'
-
-
-def render_text_block_to_markdown(block):
-    """
-    Render a text block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    # Text content is already in markdown format
-    return block.get('content', '')
-
-
-def render_heading_block_to_markdown(block):
-    """
-    Render a heading block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    level = block.get('level', 2)
-    content = block.get('content', '')
-    
-    # Ensure level is between 1-6
-    valid_level = min(max(int(level), 1), 6)
-    hashtags = '#' * valid_level
-    
-    return f'{hashtags} {content}'
-
-
-def render_image_block_to_markdown(block):
-    """
-    Render an image block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    url = block.get('url', '')
-    alt = block.get('alt', '')
-    caption = block.get('caption')
-    
-    markdown = f'![{alt}]({url})'
-    
-    if caption:
-        markdown += f'\n*{caption}*'
-    
-    return markdown
-
-
-def render_code_block_to_markdown(block):
-    """
-    Render a code block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    language = block.get('language', '')
-    content = block.get('content', '')
-    
-    return f'```{language}\n{content}\n```'
-
-
-def render_list_block_to_markdown(block):
-    """
-    Render a list block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    items = block.get('items', [])
-    # Support both snake_case (Python style) and camelCase (JS style)
-    list_type = block.get('list_type', block.get('listType', 'unordered'))
-    
-    if not items or not isinstance(items, list):
-        return '[Invalid list items]'
-    
-    markdown_items = []
-    for i, item in enumerate(items):
-        if list_type == 'ordered':
-            markdown_items.append(f'{i+1}. {item}')
-        else:
-            markdown_items.append(f'- {item}')
-    
-    return '\n'.join(markdown_items)
-
-
-def render_quote_block_to_markdown(block):
-    """
-    Render a quote block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    content = block.get('content', '')
-    attribution = block.get('attribution')
-    
-    # Prefix each line with '> '
-    markdown = '\n'.join([f'> {line}' for line in content.split('\n')])
-    
-    if attribution:
-        markdown += f'\n>\n> — {attribution}'
-    
-    return markdown
-
-
-def render_embed_block_to_markdown(block):
-    """
-    Render an embed block to Markdown
-    
-    Args:
-        block (dict): Block data
-        
-    Returns:
-        str: Markdown representation
-    """
-    url = block.get('url', '')
-    caption = block.get('caption')
-    # Support both snake_case (Python style) and camelCase (JS style)
-    embed_type = block.get('embed_type', block.get('embedType', 'generic'))
-    
-    markdown = f'[{embed_type or "Embedded content"}: {url}]({url})'
-    
-    if caption:
-        markdown += f'\n*{caption}*'
-    
-    return markdown
-</file>
-
-<file path="blockdoc/schema/__init__.py">
-# Schema module for BlockDoc
+<file path="blockdoc/conversions/__init__.py">
+__all__ = ["markdown_to_blockdoc"]
 </file>
 
 <file path="blockdoc/schema/blockdoc.schema.json">
@@ -1519,82 +478,6 @@ def render_embed_block_to_markdown(block):
     }
   }
 }
-</file>
-
-<file path="blockdoc/schema/loader.py">
-"""
-BlockDoc Schema Loader
-
-Loads the JSON schema for BlockDoc validation
-"""
-
-import json
-import os
-
-
-# Get the schema file path
-schema_path = os.path.join(os.path.dirname(__file__), 'blockdoc.schema.json')
-
-# Load schema
-with open(schema_path, 'r') as schema_file:
-    schema = json.load(schema_file)
-</file>
-
-<file path="blockdoc/utils/__init__.py">
-# Utils module for BlockDoc
-</file>
-
-<file path="blockdoc/utils/sanitize.py">
-"""
-BlockDoc HTML Sanitization
-
-Provides utilities for sanitizing HTML content
-"""
-
-import html
-import re
-
-
-def sanitize_html(html_content):
-    """
-    Simple HTML sanitizer to prevent XSS
-    
-    Args:
-        html_content (str): HTML content to sanitize
-        
-    Returns:
-        str: Sanitized HTML
-    """
-    if not html_content:
-        return ''
-    
-    return html.escape(str(html_content))
-
-
-def sanitize_url(url):
-    """
-    Sanitize a URL for safe embedding
-    
-    Args:
-        url (str): URL to sanitize
-        
-    Returns:
-        str: Sanitized URL
-    """
-    if not url:
-        return ''
-    
-    # Only allow http and https protocols
-    if re.match(r'^https?:\/\/', url, re.IGNORECASE):
-        return url
-    elif url.startswith('//'):
-        return f'https:{url}'
-    elif ':' not in url:
-        # Relative URLs are considered safe
-        return url
-    
-    # Default to empty for potentially unsafe protocols
-    return ''
 </file>
 
 <file path="docs/api-docs/renderers/html.md">
@@ -4662,455 +3545,6 @@ By breaking content into semantic blocks, you gain precise control over content 
 For more examples of BlockDoc and LLM integration, check out the [LLM Integration Examples](../../examples/llm-integration/) directory.
 </file>
 
-<file path="examples/llm-integration/llm_content_generator.py">
-"""
-BlockDoc LLM Content Generator
-
-This example demonstrates using BlockDoc with Language Models (LLMs) to generate
-and manipulate structured content.
-
-Note: This is a demonstration example. You need to provide your own API key
-and uncomment the appropriate sections to use with your preferred LLM provider.
-"""
-
-import sys
-import os
-import json
-import argparse
-import datetime
-
-# Add the parent directory to sys.path to import blockdoc
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-
-from blockdoc import BlockDocDocument, Block
-
-# Uncomment and modify the section for your preferred LLM provider:
-
-# # Option 1: OpenAI
-# import openai
-# 
-# # Set your API key
-# # openai.api_key = os.environ.get("OPENAI_API_KEY")
-# 
-# def generate_with_llm(prompt, max_tokens=800):
-#     """Generate text using OpenAI's API"""
-#     response = openai.chat.completions.create(
-#         model="gpt-4",
-#         messages=[
-#             {"role": "system", "content": "You are a helpful content creation assistant."},
-#             {"role": "user", "content": prompt}
-#         ],
-#         max_tokens=max_tokens,
-#         temperature=0.7
-#     )
-#     return response.choices[0].message.content
-
-# # Option 2: Anthropic
-# import anthropic
-# 
-# # Initialize the client
-# # client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
-# 
-# def generate_with_llm(prompt, max_tokens=800):
-#     """Generate text using Anthropic's API"""
-#     response = client.messages.create(
-#         model="claude-3-opus-20240229",
-#         max_tokens=max_tokens,
-#         temperature=0.7,
-#         system="You are a helpful content creation assistant.",
-#         messages=[
-#             {"role": "user", "content": prompt}
-#         ]
-#     )
-#     return response.content[0].text
-
-# For demonstration, we'll use a mock LLM function:
-def generate_with_llm(prompt, max_tokens=800):
-    """Mock LLM function that returns predefined responses based on the prompt"""
-    if "introduction" in prompt.lower():
-        return """BlockDoc is a powerful structured content format designed specifically for modern content workflows. 
-        It combines the simplicity of block-based editing with the flexibility of structured data, making it ideal for both human authors and AI assistants.
-        
-        In this article, we'll explore how BlockDoc works, its key features, and why it's becoming the preferred format for content-heavy applications."""
-    
-    elif "benefits" in prompt.lower() or "advantages" in prompt.lower():
-        return """1. **Semantic Structure**: Every block has a meaningful ID that describes its purpose
-2. **Granular Control**: Update or replace specific sections without touching the rest
-3. **LLM Optimization**: Perfect for AI-generated content and targeted updates
-4. **Rendering Flexibility**: Output to HTML, Markdown, or custom formats
-5. **Database Friendly**: Easy to store in document databases"""
-    
-    elif "code example" in prompt.lower():
-        return """```python
-from blockdoc import BlockDocDocument, Block
-
-# Create a new document
-doc = BlockDocDocument({
-    "title": "My First Document",
-    "metadata": {
-        "author": "BlockDoc Team",
-        "created": "2025-03-23"
-    }
-})
-
-# Add some content blocks
-doc.add_block(Block.heading("title", 1, "Welcome to BlockDoc"))
-doc.add_block(Block.text("intro", "BlockDoc makes structured content **simple**."))
-
-# Get the document as JSON
-json_doc = doc.to_json()
-print(json_doc)
-```"""
-    
-    elif "use cases" in prompt.lower():
-        return """BlockDoc is particularly well-suited for the following use cases:
-
-1. **Content Management Systems**: Provides a structured yet flexible content model
-2. **Documentation Sites**: Excellent for technical documentation with code examples
-3. **LLM Applications**: Perfect for AI-assisted content generation and editing
-4. **Blogs and Articles**: Rich content with mixed media types
-5. **Educational Content**: Structured lessons with different content blocks"""
-    
-    elif "conclusion" in prompt.lower():
-        return """As we've seen, BlockDoc offers a powerful yet simple approach to structured content. Its block-based architecture provides the perfect balance of flexibility and structure, making it adaptable to a wide range of content needs.
-
-Whether you're building a CMS, working with LLMs, or simply need a better way to organize content, BlockDoc provides a solid foundation that grows with your needs.
-
-Try BlockDoc today and experience the benefits of structured content that works for both humans and machines."""
-    
-    else:
-        return "Content generated for: " + prompt
-
-
-def create_article_with_llm(title, topic):
-    """
-    Create a complete BlockDoc article using an LLM
-    
-    Args:
-        title (str): Article title
-        topic (str): Article topic
-        
-    Returns:
-        BlockDocDocument: The generated article
-    """
-    # Create a new document
-    article = BlockDocDocument({
-        "title": title,
-        "metadata": {
-            "author": "BlockDoc LLM Assistant",
-            "created": datetime.datetime.now().isoformat(),
-            "topic": topic,
-            "generated": True
-        }
-    })
-    
-    # Generate introduction
-    intro_prompt = f"""Write an engaging introduction for an article titled "{title}" about {topic}.
-    The introduction should be 2-3 paragraphs and explain what the article will cover.
-    Use Markdown formatting where appropriate."""
-    
-    intro_content = generate_with_llm(intro_prompt)
-    article.add_block(Block.text("introduction", intro_content))
-    
-    # Generate a section about benefits/features
-    article.add_block(Block.heading("benefits", 2, f"Benefits of {topic}"))
-    
-    benefits_prompt = f"""Create a list of 4-6 key benefits or features of {topic}.
-    Each item should be 1-2 sentences and start with a bold benefit name.
-    Format as a markdown list."""
-    
-    benefits_content = generate_with_llm(benefits_prompt)
-    
-    # Parse the list items from the response
-    benefits_items = []
-    for line in benefits_content.split('\n'):
-        line = line.strip()
-        if line.startswith(('- ', '* ', '1. ')) and len(line) > 2:
-            benefits_items.append(line[2:].strip())
-        elif line and not line.startswith('#') and len(benefits_items) < 6:
-            benefits_items.append(line)
-    
-    article.add_block(Block.list("benefits-list", benefits_items, "unordered"))
-    
-    # Generate a code example section
-    article.add_block(Block.heading("code-example", 2, "Code Example"))
-    
-    code_prompt = f"""Create a Python code example related to {topic} using the BlockDoc library.
-    The example should demonstrate creating a document with blocks and rendering it.
-    Include comments to explain the code."""
-    
-    code_content = generate_with_llm(code_prompt)
-    
-    # Extract the code from markdown code blocks if present
-    if "```" in code_content:
-        code_parts = code_content.split("```")
-        if len(code_parts) >= 3:
-            # Get the content inside the code block
-            code_block = code_parts[1]
-            # Remove language identifier if present
-            if code_block.startswith(("python", "py")):
-                code_block = code_block[code_block.find("\n")+1:]
-            code_content = code_block.strip()
-    
-    article.add_block(Block.code("example-code", "python", code_content))
-    
-    # Generate a use cases section
-    article.add_block(Block.heading("use-cases", 2, "Use Cases"))
-    
-    use_cases_prompt = f"""Describe 4-5 practical use cases for {topic}.
-    Explain how each use case benefits from the features of {topic}."""
-    
-    use_cases_content = generate_with_llm(use_cases_prompt)
-    article.add_block(Block.text("use-cases-content", use_cases_content))
-    
-    # Add an image placeholder
-    article.add_block(Block.image(
-        "diagram",
-        "https://placehold.co/800x400?text=Diagram:+" + topic.replace(" ", "+"),
-        f"Diagram illustrating {topic}",
-        f"Figure 1: Visual representation of {topic}"
-    ))
-    
-    # Generate conclusion
-    article.add_block(Block.heading("conclusion", 2, "Conclusion"))
-    
-    conclusion_prompt = f"""Write a conclusion for an article about {topic}.
-    Summarize the key points and end with a call to action.
-    Keep it to 2-3 paragraphs."""
-    
-    conclusion_content = generate_with_llm(conclusion_prompt)
-    article.add_block(Block.text("conclusion-content", conclusion_content))
-    
-    return article
-
-
-def update_block_with_llm(document, block_id, instruction):
-    """
-    Update a specific block using an LLM
-    
-    Args:
-        document (BlockDocDocument): The document to update
-        block_id (str): ID of the block to update
-        instruction (str): Instructions for updating the block
-        
-    Returns:
-        BlockDocDocument: The updated document
-    """
-    # Get the existing block
-    block = document.get_block(block_id)
-    if not block:
-        raise ValueError(f"Block with ID '{block_id}' not found")
-    
-    block_type = block["type"]
-    
-    if block_type == "text":
-        # Generate updated text content
-        prompt = f"""Here is an existing text block:
-
-{block["content"]}
-
-Update this text according to these instructions: {instruction}
-
-Preserve any markdown formatting that's appropriate. Return only the updated text."""
-        
-        updated_content = generate_with_llm(prompt)
-        document.update_block(block_id, {"content": updated_content})
-    
-    elif block_type == "heading":
-        # Generate updated heading
-        prompt = f"""Here is an existing heading:
-
-{block["content"]}
-
-Update this heading according to these instructions: {instruction}
-
-Keep it concise and clear. Return only the updated heading text."""
-        
-        updated_content = generate_with_llm(prompt)
-        document.update_block(block_id, {"content": updated_content})
-    
-    elif block_type == "list":
-        # Update list items
-        items = block.get("items", [])
-        items_text = "\n".join([f"- {item}" for item in items])
-        
-        prompt = f"""Here is an existing list:
-
-{items_text}
-
-Update this list according to these instructions: {instruction}
-
-Return the updated list with each item on a new line starting with '- '."""
-        
-        updated_content = generate_with_llm(prompt)
-        
-        # Parse updated list items
-        updated_items = []
-        for line in updated_content.split('\n'):
-            line = line.strip()
-            if line.startswith(('- ', '* ', '• ')) and len(line) > 2:
-                updated_items.append(line[2:].strip())
-        
-        if updated_items:
-            document.update_block(block_id, {"items": updated_items})
-    
-    elif block_type == "code":
-        # Update code content
-        prompt = f"""Here is an existing code block in {block.get('language', 'python')}:
-
-{block["content"]}
-
-Update this code according to these instructions: {instruction}
-
-Return only the updated code, with no additional explanation."""
-        
-        updated_content = generate_with_llm(prompt)
-        
-        # Extract the code from markdown code blocks if present
-        if "```" in updated_content:
-            code_parts = updated_content.split("```")
-            if len(code_parts) >= 3:
-                # Get the content inside the code block
-                code_block = code_parts[1]
-                # Remove language identifier if present
-                if code_block.startswith(("python", "py", block.get('language', ''))):
-                    code_block = code_block[code_block.find("\n")+1:]
-                updated_content = code_block.strip()
-        
-        document.update_block(block_id, {"content": updated_content})
-    
-    return document
-
-
-def main():
-    """
-    Main function to run the example
-    """
-    parser = argparse.ArgumentParser(description="Generate content with LLMs and BlockDoc")
-    parser.add_argument("--title", default="BlockDoc: A Modern Approach to Structured Content", 
-                        help="Article title")
-    parser.add_argument("--topic", default="structured content formats for modern applications", 
-                        help="Article topic")
-    parser.add_argument("--update", action="store_true", 
-                        help="Update an existing article instead of creating a new one")
-    parser.add_argument("--input", help="Input JSON file (for update mode)")
-    parser.add_argument("--block-id", help="Block ID to update (for update mode)")
-    parser.add_argument("--instruction", help="Update instruction (for update mode)")
-    parser.add_argument("--output-dir", default="./output", help="Output directory")
-    
-    args = parser.parse_args()
-    
-    # Create output directory if it doesn't exist
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    if args.update:
-        # Update an existing document
-        if not args.input or not args.block_id or not args.instruction:
-            print("Error: update mode requires --input, --block-id, and --instruction")
-            return
-        
-        print(f"Loading document from {args.input}...")
-        with open(args.input, 'r', encoding='utf-8') as f:
-            document = BlockDocDocument.from_json(f.read())
-        
-        print(f"Updating block {args.block_id}...")
-        document = update_block_with_llm(document, args.block_id, args.instruction)
-        
-        # Save the updated document
-        output_file = os.path.basename(args.input)
-        updated_path = os.path.join(args.output_dir, f"updated_{output_file}")
-        
-        with open(updated_path, 'w', encoding='utf-8') as f:
-            f.write(document.to_json(indent=2))
-        print(f"Updated document saved to {updated_path}")
-        
-        # Also save HTML for preview
-        html_path = os.path.join(args.output_dir, f"updated_{os.path.splitext(output_file)[0]}.html")
-        with open(html_path, 'w', encoding='utf-8') as f:
-            f.write(document.render_to_html())
-        print(f"HTML preview saved to {html_path}")
-        
-    else:
-        # Create a new document
-        print(f"Generating article: {args.title} about {args.topic}...")
-        document = create_article_with_llm(args.title, args.topic)
-        
-        # Validate the document
-        print("Validating document...")
-        try:
-            document.validate()
-            print("✓ Document is valid")
-        except ValueError as e:
-            print(f"✗ Validation error: {e}")
-            return
-        
-        # Create a slug from the title for filenames
-        slug = args.title.lower().replace(" ", "-")
-        slug = ''.join(c for c in slug if c.isalnum() or c == '-')
-        
-        # Save as JSON
-        json_path = os.path.join(args.output_dir, f"{slug}.json")
-        with open(json_path, 'w', encoding='utf-8') as f:
-            f.write(document.to_json(indent=2))
-        print(f"✓ Saved JSON to {json_path}")
-        
-        # Save as HTML
-        html_path = os.path.join(args.output_dir, f"{slug}.html")
-        with open(html_path, 'w', encoding='utf-8') as f:
-            html = f"""<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{document.article["title"]}</title>
-    <style>
-        body {{ font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 20px; }}
-        .blockdoc-title {{ margin-bottom: 1.5rem; }}
-        .blockdoc-block {{ margin-bottom: 1.5rem; }}
-        .blockdoc-image {{ max-width: 100%; height: auto; }}
-        .blockdoc-caption {{ font-size: 0.9rem; color: #666; text-align: center; margin-top: 0.5rem; }}
-        .blockdoc-pre {{ background-color: #f5f5f5; border-radius: 4px; padding: 1rem; overflow-x: auto; }}
-        .blockdoc-code {{ font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 0.9rem; }}
-        .blockdoc-quote {{ border-left: 4px solid #ccc; padding-left: 1rem; font-style: italic; margin: 0; }}
-        .blockdoc-divider {{ border: 0; border-top: 1px solid #eee; margin: 2rem 0; }}
-        .author-info {{ color: #666; font-size: 0.9rem; margin-bottom: 2rem; }}
-    </style>
-</head>
-<body>
-    <div class="author-info">
-        Generated by BlockDoc LLM Assistant | {datetime.datetime.now().strftime('%Y-%m-%d')}
-    </div>
-    {document.render_to_html()}
-</body>
-</html>"""
-            f.write(html)
-        print(f"✓ Saved HTML to {html_path}")
-        
-        # Save as Markdown
-        md_path = os.path.join(args.output_dir, f"{slug}.md")
-        with open(md_path, 'w', encoding='utf-8') as f:
-            frontmatter = f"""---
-title: "{document.article["title"]}"
-author: "BlockDoc LLM Assistant"
-date: "{datetime.datetime.now().strftime('%Y-%m-%d')}"
-topic: "{args.topic}"
-generated: true
----
-
-"""
-            f.write(frontmatter + document.render_to_markdown())
-        print(f"✓ Saved Markdown to {md_path}")
-        
-        print("\nArticle generation complete!")
-        print(f"Files saved to {os.path.abspath(args.output_dir)}")
-        print("\nTo update a specific block, run:")
-        print(f"python llm_content_generator.py --update --input {json_path} --block-id BLOCK_ID --instruction \"Your instruction\"")
-
-
-if __name__ == "__main__":
-    main()
-</file>
-
 <file path="examples/llm-integration/README.md">
 # BlockDoc LLM Integration Examples
 
@@ -5238,288 +3672,254 @@ When working with BlockDoc and LLMs, consider these best practices:
 - Check out the [LLM Integration Tutorial](../../docs/tutorials/llm-integration.md) for an in-depth guide
 </file>
 
-<file path="examples/simple-blog/blog_generator.py">
-"""
-BlockDoc Simple Blog Generator
+<file path="examples/output/markdown-converted.html">
+<article class="blockdoc-article">
+<h1 class="blockdoc-title">Markdown to BlockDoc Conversion</h1>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-6bde1965" data-block-type="text"><p>This is a demonstration of converting <strong>Markdown</strong> content to BlockDoc format.</p></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="key-features" data-block-type="heading"><h2>Key Features</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-5c1cd4c6" data-block-type="text"><p>BlockDoc makes it easy to work with structured content:</p></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="unordered-list-36e4adc8" data-block-type="list"><ul class="blockdoc-list blockdoc-list-unordered"><li>Maintains semantic structure</li><li>Preserves formatting</li><li>Creates meaningful block IDs</li></ul></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="code-examples" data-block-type="heading"><h3>Code Examples</h3></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-0c25e226" data-block-type="text"><p>Here's an example of Python code:</p></div>
+<div class="blockdoc-block blockdoc-code" data-block-id="code-python-ff977aa3" data-block-type="code">
+    <pre class="blockdoc-pre">
+      <code class="blockdoc-code language-python">
+<div class="highlight"><pre><span></span><span class="kn">from</span><span class="w"> </span><span class="nn">blockdoc</span><span class="w"> </span><span class="kn">import</span> <span class="n">markdown_to_blockdoc</span>
+<span class="c1"># Convert markdown to BlockDoc</span>
+<span class="n">doc</span> <span class="o">=</span> <span class="n">markdown_to_blockdoc</span><span class="p">(</span><span class="n">markdown_text</span><span class="p">)</span>
+<span class="c1"># Export as JSON</span>
+<span class="n">json_str</span> <span class="o">=</span> <span class="n">doc</span><span class="o">.</span><span class="n">to_json</span><span class="p">()</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">json_str</span><span class="p">)</span>
+</pre></div>
+      </code>
+    </pre>
+    </div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="images-and-media" data-block-type="heading"><h2>Images and Media</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-c3fdfd77" data-block-type="text"><p>Images are properly converted:</p></div>
+<div class="blockdoc-block blockdoc-image" data-block-id="image-101fc707" data-block-type="image"><figure class="blockdoc-figure"><img src="https://placehold.co/600x400?text=Example+Image" alt="Example image" class="blockdoc-image" /><figcaption class="blockdoc-caption">Example image caption</figcaption></figure></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="block-quotes" data-block-type="heading"><h2>Block Quotes</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-8a6ab0c7" data-block-type="text"><p>BlockDoc handles various content types:</p></div>
+<div class="blockdoc-block blockdoc-quote" data-block-id="quote-25f02b35" data-block-type="quote"><blockquote class="blockdoc-quote"><p>This is a block quote that will be properly converted
+to a BlockDoc quote block, preserving its formatting
+and presentation.</p></blockquote><cite class="blockdoc-attribution">Attribution Source</cite></div>
+<div class="blockdoc-block blockdoc-divider" data-block-id="divider-f94a9524" data-block-type="divider"><hr class="blockdoc-divider" /></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="lists" data-block-type="heading"><h2>Lists</h2></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="ordered-list-414f8890" data-block-type="list"><ol class="blockdoc-list blockdoc-list-ordered"><li>Ordered lists work great</li><li>With multiple items</li><li>Preserving the numbering</li></ol></div>
+<div class="blockdoc-block blockdoc-list" data-block-id="unordered-list-d682e69f" data-block-type="list"><ul class="blockdoc-list blockdoc-list-unordered"><li>Unordered lists too</li><li>With proper nesting</li><li>And formatting</li></ul></div>
+<div class="blockdoc-block blockdoc-heading" data-block-id="the-end" data-block-type="heading"><h2>The End</h2></div>
+<div class="blockdoc-block blockdoc-text" data-block-id="text-78faa450" data-block-type="text"><p>This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving
+the document structure while enabling all the benefits of block-based content.</p></div>
+</article>
+</file>
 
-This example demonstrates using BlockDoc to create and manage blog posts.
-"""
+<file path="examples/output/markdown-converted.json">
+{
+  "article": {
+    "title": "Markdown to BlockDoc Conversion",
+    "metadata": {
+      "author": "BlockDoc Team",
+      "publishedDate": "2025-04-25T15:51:21.904700",
+      "tags": [
+        "markdown",
+        "conversion",
+        "example"
+      ]
+    },
+    "blocks": [
+      {
+        "id": "text-6bde1965",
+        "type": "text",
+        "content": "This is a demonstration of converting **Markdown** content to BlockDoc format."
+      },
+      {
+        "id": "key-features",
+        "type": "heading",
+        "content": "Key Features",
+        "level": 2
+      },
+      {
+        "id": "text-5c1cd4c6",
+        "type": "text",
+        "content": "BlockDoc makes it easy to work with structured content:"
+      },
+      {
+        "id": "unordered-list-36e4adc8",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Maintains semantic structure",
+          "Preserves formatting",
+          "Creates meaningful block IDs"
+        ],
+        "list_type": "unordered"
+      },
+      {
+        "id": "code-examples",
+        "type": "heading",
+        "content": "Code Examples",
+        "level": 3
+      },
+      {
+        "id": "text-0c25e226",
+        "type": "text",
+        "content": "Here's an example of Python code:"
+      },
+      {
+        "id": "code-python-ff977aa3",
+        "type": "code",
+        "content": "from blockdoc import markdown_to_blockdoc\n\n# Convert markdown to BlockDoc\ndoc = markdown_to_blockdoc(markdown_text)\n\n# Export as JSON\njson_str = doc.to_json()\nprint(json_str)",
+        "language": "python"
+      },
+      {
+        "id": "images-and-media",
+        "type": "heading",
+        "content": "Images and Media",
+        "level": 2
+      },
+      {
+        "id": "text-c3fdfd77",
+        "type": "text",
+        "content": "Images are properly converted:"
+      },
+      {
+        "id": "image-101fc707",
+        "type": "image",
+        "content": "",
+        "url": "https://placehold.co/600x400?text=Example+Image",
+        "alt": "Example image",
+        "caption": "Example image caption"
+      },
+      {
+        "id": "block-quotes",
+        "type": "heading",
+        "content": "Block Quotes",
+        "level": 2
+      },
+      {
+        "id": "text-8a6ab0c7",
+        "type": "text",
+        "content": "BlockDoc handles various content types:"
+      },
+      {
+        "id": "quote-25f02b35",
+        "type": "quote",
+        "content": "This is a block quote that will be properly converted\nto a BlockDoc quote block, preserving its formatting\nand presentation.",
+        "attribution": "Attribution Source"
+      },
+      {
+        "id": "divider-f94a9524",
+        "type": "divider",
+        "content": ""
+      },
+      {
+        "id": "lists",
+        "type": "heading",
+        "content": "Lists",
+        "level": 2
+      },
+      {
+        "id": "ordered-list-414f8890",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Ordered lists work great",
+          "With multiple items",
+          "Preserving the numbering"
+        ],
+        "list_type": "ordered"
+      },
+      {
+        "id": "unordered-list-d682e69f",
+        "type": "list",
+        "content": "",
+        "items": [
+          "Unordered lists too",
+          "With proper nesting",
+          "And formatting"
+        ],
+        "list_type": "unordered"
+      },
+      {
+        "id": "the-end",
+        "type": "heading",
+        "content": "The End",
+        "level": 2
+      },
+      {
+        "id": "text-78faa450",
+        "type": "text",
+        "content": "This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving\nthe document structure while enabling all the benefits of block-based content."
+      }
+    ]
+  }
+}
+</file>
 
-import sys
-import os
-import json
-import datetime
-import argparse
+<file path="examples/output/markdown-roundtrip.md">
+# Markdown to BlockDoc Conversion
 
-# Add the parent directory to sys.path to import blockdoc
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+> Author: BlockDoc Team
+> Published: Fri Apr 25 2025
+> Tags: markdown, conversion, example
 
-from blockdoc import BlockDocDocument, Block
+This is a demonstration of converting **Markdown** content to BlockDoc format.
 
+## Key Features
 
-def create_blog_post(title, author, content_json=None):
-    """
-    Create a blog post using BlockDoc
-    
-    Args:
-        title (str): Blog post title
-        author (str): Blog post author
-        content_json (str): Optional path to JSON file with content structure
-        
-    Returns:
-        BlockDocDocument: The created blog post
-    """
-    # Create a new document with metadata
-    blog_post = BlockDocDocument({
-        "title": title,
-        "metadata": {
-            "author": author,
-            "publishedDate": datetime.datetime.now().isoformat(),
-            "type": "blog-post",
-            "tags": ["blockdoc", "example", "blog"]
-        }
-    })
-    
-    if content_json:
-        # Load content structure from JSON file
-        with open(content_json, 'r', encoding='utf-8') as f:
-            content_structure = json.load(f)
-            
-        # Process the content structure
-        for item in content_structure:
-            block_type = item.get("type")
-            block_id = item.get("id")
-            
-            if block_type == "text":
-                blog_post.add_block(Block.text(
-                    block_id,
-                    item.get("content", "")
-                ))
-            
-            elif block_type == "heading":
-                blog_post.add_block(Block.heading(
-                    block_id,
-                    item.get("level", 2),
-                    item.get("content", "")
-                ))
-            
-            elif block_type == "image":
-                blog_post.add_block(Block.image(
-                    block_id,
-                    item.get("url", ""),
-                    item.get("alt", ""),
-                    item.get("caption")
-                ))
-            
-            elif block_type == "code":
-                blog_post.add_block(Block.code(
-                    block_id,
-                    item.get("language", "text"),
-                    item.get("content", "")
-                ))
-            
-            elif block_type == "list":
-                blog_post.add_block(Block.list(
-                    block_id,
-                    item.get("items", []),
-                    item.get("list_type", "unordered")
-                ))
-            
-            elif block_type == "quote":
-                blog_post.add_block(Block.quote(
-                    block_id,
-                    item.get("content", ""),
-                    item.get("attribution")
-                ))
-            
-            elif block_type == "divider":
-                blog_post.add_block(Block.divider(block_id))
-                
-    else:
-        # Create a default structure if no JSON provided
-        blog_post.add_block(Block.text(
-            "introduction",
-            "Welcome to this blog post created with BlockDoc! BlockDoc makes it easy to create structured content that can be rendered in different formats."
-        ))
-        
-        blog_post.add_block(Block.heading(
-            "about-blockdoc",
-            2,
-            "About BlockDoc"
-        ))
-        
-        blog_post.add_block(Block.text(
-            "blockdoc-description",
-            "BlockDoc is a simple, powerful standard for structured content that works beautifully with LLMs, humans, and modern editors. It provides a block-based architecture where content is organized into discrete, individually addressable blocks."
-        ))
-        
-        blog_post.add_block(Block.heading(
-            "features-heading",
-            2,
-            "Key Features"
-        ))
-        
-        blog_post.add_block(Block.list(
-            "features-list",
-            [
-                "**LLM-friendly**: Optimized for AI generation and modification",
-                "**Block-based**: Content is divided into semantic blocks",
-                "**Flexible**: Supports various content types and structures",
-                "**Renderer-agnostic**: Output to HTML, Markdown, or custom formats"
-            ],
-            "unordered"
-        ))
-        
-        blog_post.add_block(Block.image(
-            "example-image",
-            "https://placehold.co/600x400?text=BlockDoc+Example",
-            "Example BlockDoc structure visualization",
-            "Figure: Visualization of a BlockDoc document structure"
-        ))
-        
-        blog_post.add_block(Block.heading(
-            "code-example-heading",
-            2,
-            "Code Example"
-        ))
-        
-        blog_post.add_block(Block.code(
-            "python-example",
-            "python",
-            """from blockdoc import BlockDocDocument, Block
+BlockDoc makes it easy to work with structured content:
 
-# Create a document
-doc = BlockDocDocument({
-    "title": "My Document"
-})
+- Maintains semantic structure
+- Preserves formatting
+- Creates meaningful block IDs
 
-# Add a text block
-doc.add_block(Block.text("intro", "This is the introduction."))
+### Code Examples
 
-# Render to HTML
-html = doc.render_to_html()
-"""
-        ))
-        
-        blog_post.add_block(Block.heading(
-            "conclusion-heading",
-            2,
-            "Conclusion"
-        ))
-        
-        blog_post.add_block(Block.text(
-            "conclusion",
-            "This example demonstrates how easy it is to create structured content with BlockDoc. Check out the [GitHub repository](https://github.com/berrydev-ai/blockdoc-python) for more information and examples."
-        ))
-    
-    return blog_post
+Here's an example of Python code:
 
+```python
+from blockdoc import markdown_to_blockdoc
 
-def main():
-    """
-    Main function to run the blog generator
-    """
-    parser = argparse.ArgumentParser(description="Generate a blog post using BlockDoc")
-    parser.add_argument("--title", default="BlockDoc Blog Example", help="Blog post title")
-    parser.add_argument("--author", default="BlockDoc Team", help="Blog post author")
-    parser.add_argument("--content", help="Path to JSON file with content structure")
-    parser.add_argument("--output-dir", default="./output", help="Output directory for generated files")
-    
-    args = parser.parse_args()
-    
-    # Create output directory if it doesn't exist
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    # Create the blog post
-    print(f"Creating blog post: {args.title} by {args.author}")
-    blog_post = create_blog_post(args.title, args.author, args.content)
-    
-    # Validate the document
-    print("Validating document...")
-    try:
-        blog_post.validate()
-        print("✓ Document is valid")
-    except ValueError as e:
-        print(f"✗ Validation error: {e}")
-        return
-    
-    # Create a slug from the title for filenames
-    slug = args.title.lower().replace(" ", "-")
-    slug = ''.join(c for c in slug if c.isalnum() or c == '-')
-    
-    # Save as JSON
-    json_path = os.path.join(args.output_dir, f"{slug}.json")
-    with open(json_path, 'w', encoding='utf-8') as f:
-        f.write(blog_post.to_json(indent=2))
-    print(f"✓ Saved JSON to {json_path}")
-    
-    # Render to HTML
-    html_path = os.path.join(args.output_dir, f"{slug}.html")
-    with open(html_path, 'w', encoding='utf-8') as f:
-        # Add basic styling
-        html = """<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{title}</title>
-    <style>
-        body {{ font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 20px; }}
-        .blockdoc-title {{ margin-bottom: 1.5rem; }}
-        .blockdoc-block {{ margin-bottom: 1.5rem; }}
-        .blockdoc-image {{ max-width: 100%; height: auto; }}
-        .blockdoc-caption {{ font-size: 0.9rem; color: #666; text-align: center; margin-top: 0.5rem; }}
-        .blockdoc-pre {{ background-color: #f5f5f5; border-radius: 4px; padding: 1rem; overflow-x: auto; }}
-        .blockdoc-code {{ font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 0.9rem; }}
-        .blockdoc-quote {{ border-left: 4px solid #ccc; padding-left: 1rem; font-style: italic; margin: 0; }}
-        .blockdoc-attribution {{ display: block; text-align: right; font-style: normal; font-size: 0.9rem; margin-top: 0.5rem; }}
-        .blockdoc-divider {{ border: 0; border-top: 1px solid #eee; margin: 2rem 0; }}
-        .author-info {{ color: #666; font-size: 0.9rem; margin-bottom: 2rem; }}
-        .blockdoc-list {{ padding-left: 20px; }}
-    </style>
-</head>
-<body>
-""".format(title=blog_post.article["title"])
-        
-        # Add author info
-        html += f"""<div class="author-info">
-    By {blog_post.article["metadata"].get("author", "Unknown")} | 
-    Published: {blog_post.article["metadata"].get("publishedDate", "").split("T")[0]}
-</div>
-"""
-        
-        # Add the rendered content
-        html += blog_post.render_to_html()
-        
-        # Close the HTML
-        html += """
-</body>
-</html>
-"""
-        f.write(html)
-    print(f"✓ Saved HTML to {html_path}")
-    
-    # Render to Markdown
-    md_path = os.path.join(args.output_dir, f"{slug}.md")
-    with open(md_path, 'w', encoding='utf-8') as f:
-        # Add YAML frontmatter
-        frontmatter = f"""---
-title: "{blog_post.article["title"]}"
-author: "{blog_post.article["metadata"].get("author", "Unknown")}"
-date: "{blog_post.article["metadata"].get("publishedDate", "").split("T")[0]}"
-tags: {blog_post.article["metadata"].get("tags", [])}
+# Convert markdown to BlockDoc
+doc = markdown_to_blockdoc(markdown_text)
+
+# Export as JSON
+json_str = doc.to_json()
+print(json_str)
+```
+
+## Images and Media
+
+Images are properly converted:
+
+![Example image](https://placehold.co/600x400?text=Example+Image)
+*Example image caption*
+
+## Block Quotes
+
+BlockDoc handles various content types:
+
+> This is a block quote that will be properly converted
+> to a BlockDoc quote block, preserving its formatting
+> and presentation.
+>
+> — Attribution Source
+
 ---
 
-"""
-        f.write(frontmatter + blog_post.render_to_markdown())
-    print(f"✓ Saved Markdown to {md_path}")
-    
-    print("\nBlog post generation complete!")
-    print(f"Files saved to {os.path.abspath(args.output_dir)}")
+## Lists
 
+1. Ordered lists work great
+2. With multiple items
+3. Preserving the numbering
 
-if __name__ == "__main__":
-    main()
+- Unordered lists too
+- With proper nesting
+- And formatting
+
+## The End
+
+This example shows how Markdown can be seamlessly converted to BlockDoc format, preserving
+the document structure while enabling all the benefits of block-based content.
 </file>
 
 <file path="examples/simple-blog/README.md">
@@ -5752,223 +4152,17 @@ This example can be adapted for various content creation workflows:
 ]
 </file>
 
-<file path="examples/basic_example.py">
-"""
-BlockDoc Basic Example
-
-This example demonstrates creating and rendering a simple document using BlockDoc
-"""
-
-import sys
-import os
-import json
-import subprocess
-from datetime import datetime
-
-# Add the parent directory to sys.path to import blockdoc
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-# Check and install required dependencies
-try:
-    import markdown
-    import pygments
-    import jsonschema
-except ImportError:
-    print("Installing required dependencies...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "markdown", "pygments", "jsonschema"])
-    print("Dependencies installed successfully.")
-
-from blockdoc import BlockDocDocument, Block
-
-
-def create_blog_post():
-    """
-    Create a sample blog post
-    
-    Returns:
-        BlockDocDocument: The created document
-    """
-    # Create a new document
-    blog_post = BlockDocDocument({
-        "title": "Getting Started with BlockDoc",
-        "metadata": {
-            "author": "BlockDoc Team",
-            "publishedDate": datetime.now().isoformat(),
-            "tags": ["blockdoc", "tutorial", "content", "structured-data"]
-        }
-    })
-    
-    # Add an introduction
-    blog_post.add_block(Block.text(
-        "intro",
-        "Welcome to **BlockDoc**, a simple yet powerful format for structured content. "
-        "In this tutorial, we'll explore the basics of creating and working with BlockDoc documents."
-    ))
-    
-    # Add a heading
-    blog_post.add_block(Block.heading(
-        "what-is-blockdoc",
-        2,
-        "What is BlockDoc?"
-    ))
-    
-    # Add content explaining BlockDoc
-    blog_post.add_block(Block.text(
-        "blockdoc-explanation",
-        "BlockDoc is a structured content format designed for:\n\n"
-        "* **LLM-friendly** - Optimized for generation and modification by AI\n"
-        "* **Block-based** - Content is divided into modular blocks with semantic IDs\n"
-        "* **Flexible** - Supports various content types and nested structures\n"
-        "* **Database-ready** - Easy to store in document databases\n"
-        "* **Renderer-agnostic** - Output to HTML, Markdown, or other formats"
-    ))
-    
-    # Add a code example
-    blog_post.add_block(Block.code(
-        "code-example",
-        "python",
-        """# Create a new BlockDoc document
-doc = BlockDocDocument({
-    "title": "My First Document",
-})
-
-# Add some content blocks
-doc.add_block(Block.heading("intro-heading", 2, "Introduction"))
-doc.add_block(Block.text("intro-text", "This is my **first** BlockDoc document."))
-
-# Render to HTML
+<file path="examples/markdown_conversion_example.py">
+SAMPLE_MARKDOWN = """# Markdown to BlockDoc Conversion
+def main()
+⋮----
+doc = markdown_to_blockdoc(
+⋮----
+output_dir = os.path.join(os.path.dirname(__file__), "output")
+⋮----
+markdown = doc.render_to_markdown()
+⋮----
 html = doc.render_to_html()
-print(html)"""
-    ))
-    
-    # Add an image
-    blog_post.add_block(Block.image(
-        "sample-image",
-        "https://placehold.co/600x400?text=BlockDoc+Example",
-        "A sample BlockDoc document structure",
-        "Figure 1: Visual representation of a BlockDoc document"
-    ))
-    
-    # Add another heading
-    blog_post.add_block(Block.heading(
-        "block-types",
-        2,
-        "Supported Block Types"
-    ))
-    
-    # Add a list of block types
-    blog_post.add_block(Block.list(
-        "block-types-list",
-        [
-            "**Text**: Markdown-formatted text content",
-            "**Heading**: Section headings with levels 1-6",
-            "**Image**: Images with URL, alt text, and optional caption",
-            "**Code**: Code snippets with language highlighting",
-            "**List**: Ordered or unordered lists",
-            "**Quote**: Blockquotes with optional attribution",
-            "**Embed**: Embedded content like videos or tweets",
-            "**Divider**: Horizontal dividers between sections"
-        ],
-        "unordered"
-    ))
-    
-    # Add a quote
-    blog_post.add_block(Block.text(
-        "quote-intro",
-        "BlockDoc was designed with a specific philosophy in mind:"
-    ))
-    
-    quote_block = Block({
-        "id": "philosophy-quote",
-        "type": "quote",
-        "content": "Content should be structured in a way that is meaningful to both humans and machines, allowing for precise updates and transformations while maintaining semantic context.",
-        "attribution": "BlockDoc Design Principles"
-    })
-    
-    blog_post.add_block(quote_block)
-    
-    # Add a conclusion
-    blog_post.add_block(Block.heading(
-        "conclusion",
-        2,
-        "Getting Started"
-    ))
-    
-    blog_post.add_block(Block.text(
-        "conclusion-text",
-        "Ready to try BlockDoc for yourself? Check out our [GitHub repository](https://github.com/berrydev-ai/blockdoc-python) and follow the installation instructions to get started.\n\n"
-        "BlockDoc is perfect for content-heavy applications, CMS systems, documentation sites, and anywhere else you need structured, maintainable content."
-    ))
-    
-    # Add a divider
-    blog_post.add_block(Block.divider("end-divider"))
-    
-    # Return the document
-    return blog_post
-
-
-def main():
-    """
-    Main function to run the example
-    """
-    print("Creating a sample BlockDoc blog post...")
-    blog_post = create_blog_post()
-    
-    # Validate the document against the schema
-    print("Validating against schema...")
-    try:
-        blog_post.validate()
-        print("✓ Document is valid")
-    except ValueError as e:
-        print(f"✗ Validation failed: {e}")
-        return
-    
-    # Create output directory
-    output_dir = os.path.join(os.path.dirname(__file__), 'output')
-    os.makedirs(output_dir, exist_ok=True)
-    
-    # Save the document as JSON
-    print("Saving document as JSON...")
-    with open(os.path.join(output_dir, 'blog-post.json'), 'w', encoding='utf-8') as f:
-        f.write(blog_post.to_json())
-    
-    # Render to HTML
-    print("Rendering to HTML...")
-    html = blog_post.render_to_html()
-    with open(os.path.join(output_dir, 'blog-post.html'), 'w', encoding='utf-8') as f:
-        f.write(html)
-    
-    # Render to Markdown
-    print("Rendering to Markdown...")
-    markdown = blog_post.render_to_markdown()
-    with open(os.path.join(output_dir, 'blog-post.md'), 'w', encoding='utf-8') as f:
-        f.write(markdown)
-    
-    # Example of updating a block
-    print("Updating a block...")
-    blog_post.update_block("blockdoc-explanation", {
-        "content": "BlockDoc is a powerful structured content format designed for:\n\n"
-                 "* **LLM-friendly** - Optimized for generation and modification by AI\n"
-                 "* **Block-based** - Content is divided into modular blocks with semantic IDs\n"
-                 "* **Flexible** - Supports various content types and nested structures\n"
-                 "* **Database-ready** - Easy to store in document databases\n"
-                 "* **Renderer-agnostic** - Output to HTML, Markdown, or other formats\n"
-                 "* **Version control friendly** - Easy to track changes to specific content blocks"
-    })
-    
-    print("Saving updated document...")
-    with open(os.path.join(output_dir, 'blog-post-updated.json'), 'w', encoding='utf-8') as f:
-        f.write(blog_post.to_json())
-    
-    print("Example complete! Output files saved to:", output_dir)
-    print("• blog-post.json - The BlockDoc document in JSON format")
-    print("• blog-post.html - The document rendered to HTML")
-    print("• blog-post.md - The document rendered to Markdown")
-    print("• blog-post-updated.json - The document after updating a block")
-
-
-if __name__ == "__main__":
-    main()
 </file>
 
 <file path="examples/README.md">
@@ -6049,501 +4243,39 @@ Most examples generate output files in an `output` directory within the example 
 If you create interesting examples using BlockDoc, we'd love to see them! Consider contributing to the project by submitting a pull request with your example.
 </file>
 
-<file path="tests/core/__init__.py">
-# Core tests package
-</file>
-
-<file path="tests/core/test_block.py">
-"""
-Tests for Block class
-"""
-
-import pytest
-from blockdoc.core.block import Block, ALLOWED_TYPES
-
-
-def test_block_init():
-    """Test Block initialization with valid data"""
-    # Test text block
-    text_block = Block({
-        'id': 'intro',
-        'type': 'text',
-        'content': 'Hello world'
-    })
-    assert text_block.id == 'intro'
-    assert text_block.type == 'text'
-    assert text_block.content == 'Hello world'
-    
-    # Test heading block
-    heading_block = Block({
-        'id': 'title',
-        'type': 'heading',
-        'level': 1,
-        'content': 'Title'
-    })
-    assert heading_block.id == 'title'
-    assert heading_block.type == 'heading'
-    assert heading_block.level == 1
-    assert heading_block.content == 'Title'
-
-
-def test_block_init_missing_id():
-    """Test Block initialization with missing ID"""
-    with pytest.raises(ValueError) as excinfo:
-        Block({
-            'type': 'text',
-            'content': 'Hello world'
-        })
-    assert 'Block ID is required' in str(excinfo.value)
-
-
-def test_block_init_invalid_type():
-    """Test Block initialization with invalid type"""
-    with pytest.raises(ValueError) as excinfo:
-        Block({
-            'id': 'intro',
-            'type': 'invalid-type',
-            'content': 'Hello world'
-        })
-    assert 'Invalid block type' in str(excinfo.value)
-    assert 'invalid-type' in str(excinfo.value)
-    for allowed_type in ALLOWED_TYPES:
-        assert allowed_type in str(excinfo.value)
-
-
-def test_block_init_missing_required_props():
-    """Test Block initialization with missing required properties for specific types"""
-    # Heading without level
-    with pytest.raises(ValueError) as excinfo:
-        Block({
-            'id': 'title',
-            'type': 'heading',
-            'content': 'Title'
-        })
-    assert 'requires property "level"' in str(excinfo.value)
-    
-    # Code without language
-    with pytest.raises(ValueError) as excinfo:
-        Block({
-            'id': 'code',
-            'type': 'code',
-            'content': 'function() {}'
-        })
-    assert 'requires property "language"' in str(excinfo.value)
-    
-    # Image without url and alt
-    with pytest.raises(ValueError) as excinfo:
-        Block({
-            'id': 'image',
-            'type': 'image',
-            'content': ''
-        })
-    assert 'requires property' in str(excinfo.value) and ('url' in str(excinfo.value) or 'alt' in str(excinfo.value))
-
-
-def test_block_update():
-    """Test Block.update method"""
-    block = Block({
-        'id': 'intro',
-        'type': 'text',
-        'content': 'Hello world'
-    })
-    
-    # Update content
-    block.update({
-        'content': 'Updated content'
-    })
-    assert block.content == 'Updated content'
-    
-    # Try to update id and type (should be ignored)
-    block.update({
-        'id': 'new-id',
-        'type': 'heading',
-        'content': 'New content'
-    })
-    assert block.id == 'intro'  # Unchanged
-    assert block.type == 'text'  # Unchanged
-    assert block.content == 'New content'  # Changed
-
-
-def test_block_to_dict():
-    """Test Block.to_dict method"""
-    block_data = {
-        'id': 'intro',
-        'type': 'text',
-        'content': 'Hello world'
-    }
-    block = Block(block_data)
-    
-    # Convert to dict and verify
-    result = block.to_dict()
-    assert result == block_data
-
-
-def test_block_factory_methods():
-    """Test Block factory methods"""
-    # Text block
-    text_block = Block.text('intro', 'Hello world')
-    assert text_block.id == 'intro'
-    assert text_block.type == 'text'
-    assert text_block.content == 'Hello world'
-    
-    # Heading block
-    heading_block = Block.heading('title', 1, 'Title')
-    assert heading_block.id == 'title'
-    assert heading_block.type == 'heading'
-    assert heading_block.level == 1
-    assert heading_block.content == 'Title'
-    
-    # Image block
-    image_block = Block.image('hero', 'https://example.com/image.jpg', 'Alt text', 'Caption')
-    assert image_block.id == 'hero'
-    assert image_block.type == 'image'
-    assert image_block.url == 'https://example.com/image.jpg'
-    assert image_block.alt == 'Alt text'
-    assert image_block.caption == 'Caption'
-    
-    # Code block
-    code_block = Block.code('snippet', 'javascript', 'console.log("Hello");')
-    assert code_block.id == 'snippet'
-    assert code_block.type == 'code'
-    assert code_block.language == 'javascript'
-    assert code_block.content == 'console.log("Hello");'
-    
-    # List block
-    list_block = Block.list('items', ['Item 1', 'Item 2'], 'ordered')
-    assert list_block.id == 'items'
-    assert list_block.type == 'list'
-    assert list_block.items == ['Item 1', 'Item 2']
-    assert list_block.list_type == 'ordered'
-    
-    # Quote block
-    quote_block = Block.quote('quote', 'Famous quote', 'Famous person')
-    assert quote_block.id == 'quote'
-    assert quote_block.type == 'quote'
-    assert quote_block.content == 'Famous quote'
-    assert quote_block.attribution == 'Famous person'
-    
-    # Embed block
-    embed_block = Block.embed('video', 'https://youtube.com/watch?v=123', 'youtube', 'Video caption')
-    assert embed_block.id == 'video'
-    assert embed_block.type == 'embed'
-    assert embed_block.url == 'https://youtube.com/watch?v=123'
-    assert embed_block.embed_type == 'youtube'
-    assert embed_block.caption == 'Video caption'
-    
-    # Divider block
-    divider_block = Block.divider('separator')
-    assert divider_block.id == 'separator'
-    assert divider_block.type == 'divider'
-    assert divider_block.content == ''
-</file>
-
-<file path="tests/core/test_document.py">
-"""
-Tests for BlockDocDocument class
-"""
-
-import json
-import pytest
-from blockdoc.core.document import BlockDocDocument
-from blockdoc.core.block import Block
-
-
-def test_document_init():
-    """Test document initialization with valid data"""
-    # Test with minimal options
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    assert doc.article['title'] == 'Test Document'
-    assert doc.article['metadata'] == {}
-    assert doc.article['blocks'] == []
-    
-    # Test with metadata
-    doc = BlockDocDocument({
-        'title': 'Test Document',
-        'metadata': {
-            'author': 'Test Author',
-            'tags': ['test', 'document']
-        }
-    })
-    assert doc.article['title'] == 'Test Document'
-    assert doc.article['metadata']['author'] == 'Test Author'
-    assert doc.article['metadata']['tags'] == ['test', 'document']
-    
-    # Test with initial blocks
-    doc = BlockDocDocument({
-        'title': 'Test Document',
-        'blocks': [
-            {
-                'id': 'intro',
-                'type': 'text',
-                'content': 'Introduction'
-            },
-            {
-                'id': 'heading',
-                'type': 'heading',
-                'level': 2,
-                'content': 'Section'
-            }
-        ]
-    })
-    assert len(doc.article['blocks']) == 2
-    assert doc.article['blocks'][0]['id'] == 'intro'
-    assert doc.article['blocks'][1]['id'] == 'heading'
-
-
-def test_document_init_missing_title():
-    """Test document initialization with missing title"""
-    with pytest.raises(ValueError) as excinfo:
-        BlockDocDocument({})
-    assert 'Document title is required' in str(excinfo.value)
-
-
-def test_document_add_block():
-    """Test add_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add a block
-    block = doc.add_block({
-        'id': 'intro',
-        'type': 'text',
-        'content': 'Introduction'
-    })
-    
-    assert isinstance(block, Block)
-    assert len(doc.article['blocks']) == 1
-    assert doc.article['blocks'][0]['id'] == 'intro'
-    assert doc.article['blocks'][0]['type'] == 'text'
-    assert doc.article['blocks'][0]['content'] == 'Introduction'
-    
-    # Add a Block instance
-    heading_block = Block.heading('heading', 2, 'Section')
-    doc.add_block(heading_block)
-    
-    assert len(doc.article['blocks']) == 2
-    assert doc.article['blocks'][1]['id'] == 'heading'
-    assert doc.article['blocks'][1]['type'] == 'heading'
-    assert doc.article['blocks'][1]['level'] == 2
-    
-    # Try adding a block with existing ID
-    with pytest.raises(ValueError) as excinfo:
-        doc.add_block({
-            'id': 'intro',
-            'type': 'text',
-            'content': 'New introduction'
-        })
-    assert "Block with ID 'intro' already exists" in str(excinfo.value)
-
-
-def test_document_insert_block():
-    """Test insert_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add some blocks
-    doc.add_block(Block.text('intro', 'Introduction'))
-    doc.add_block(Block.text('conclusion', 'Conclusion'))
-    
-    # Insert a block in the middle
-    doc.insert_block(Block.heading('heading', 2, 'Section'), 1)
-    
-    assert len(doc.article['blocks']) == 3
-    assert doc.article['blocks'][0]['id'] == 'intro'
-    assert doc.article['blocks'][1]['id'] == 'heading'
-    assert doc.article['blocks'][2]['id'] == 'conclusion'
-
-
-def test_document_get_block():
-    """Test get_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add a block
-    doc.add_block(Block.text('intro', 'Introduction'))
-    
-    # Get the block
-    block = doc.get_block('intro')
-    assert block is not None
-    assert block['id'] == 'intro'
-    assert block['content'] == 'Introduction'
-    
-    # Get a non-existent block
-    block = doc.get_block('nonexistent')
-    assert block is None
-
-
-def test_document_update_block():
-    """Test update_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add a block
-    doc.add_block(Block.text('intro', 'Introduction'))
-    
-    # Update the block
-    updated_block = doc.update_block('intro', {
-        'content': 'Updated introduction'
-    })
-    
-    assert updated_block['content'] == 'Updated introduction'
-    assert doc.article['blocks'][0]['content'] == 'Updated introduction'
-    
-    # Try to update a non-existent block
-    with pytest.raises(ValueError) as excinfo:
-        doc.update_block('nonexistent', {
-            'content': 'Content'
-        })
-    assert "Block with ID 'nonexistent' not found" in str(excinfo.value)
-
-
-def test_document_remove_block():
-    """Test remove_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add blocks
-    doc.add_block(Block.text('intro', 'Introduction'))
-    doc.add_block(Block.text('content', 'Content'))
-    
-    # Remove a block
-    result = doc.remove_block('intro')
-    assert result is True
-    assert len(doc.article['blocks']) == 1
-    assert doc.article['blocks'][0]['id'] == 'content'
-    
-    # Try to remove a non-existent block
-    result = doc.remove_block('nonexistent')
-    assert result is False
-
-
-def test_document_move_block():
-    """Test move_block method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    # Add blocks
-    doc.add_block(Block.text('intro', 'Introduction'))
-    doc.add_block(Block.text('content', 'Content'))
-    doc.add_block(Block.text('conclusion', 'Conclusion'))
-    
-    # Move a block
-    result = doc.move_block('conclusion', 0)
-    assert result is True
-    assert doc.article['blocks'][0]['id'] == 'conclusion'
-    assert doc.article['blocks'][1]['id'] == 'intro'
-    assert doc.article['blocks'][2]['id'] == 'content'
-    
-    # Try to move a non-existent block
-    result = doc.move_block('nonexistent', 0)
-    assert result is False
-    
-    # Try to move to an invalid position
-    with pytest.raises(ValueError) as excinfo:
-        doc.move_block('intro', 10)
-    assert "Invalid position" in str(excinfo.value)
-
-
-def test_document_to_dict():
-    """Test to_dict method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document',
-        'metadata': {
-            'author': 'Test Author'
-        }
-    })
-    
-    doc.add_block(Block.text('intro', 'Introduction'))
-    
-    # Convert to dict
-    result = doc.to_dict()
-    assert result['article']['title'] == 'Test Document'
-    assert result['article']['metadata']['author'] == 'Test Author'
-    assert len(result['article']['blocks']) == 1
-    assert result['article']['blocks'][0]['id'] == 'intro'
-
-
-def test_document_to_json():
-    """Test to_json method"""
-    doc = BlockDocDocument({
-        'title': 'Test Document'
-    })
-    
-    doc.add_block(Block.text('intro', 'Introduction'))
-    
-    # Convert to JSON
-    json_str = doc.to_json()
-    data = json.loads(json_str)
-    
-    assert data['article']['title'] == 'Test Document'
-    assert len(data['article']['blocks']) == 1
-    assert data['article']['blocks'][0]['id'] == 'intro'
-
-
-def test_document_from_dict():
-    """Test from_dict method"""
-    data = {
-        'article': {
-            'title': 'Test Document',
-            'metadata': {
-                'author': 'Test Author'
-            },
-            'blocks': [
-                {
-                    'id': 'intro',
-                    'type': 'text',
-                    'content': 'Introduction'
-                }
-            ]
-        }
-    }
-    
-    # Create document from dict
-    doc = BlockDocDocument.from_dict(data)
-    
-    assert doc.article['title'] == 'Test Document'
-    assert doc.article['metadata']['author'] == 'Test Author'
-    assert len(doc.article['blocks']) == 1
-    assert doc.article['blocks'][0]['id'] == 'intro'
-
-
-def test_document_from_json():
-    """Test from_json method"""
-    json_str = json.dumps({
-        'article': {
-            'title': 'Test Document',
-            'metadata': {
-                'author': 'Test Author'
-            },
-            'blocks': [
-                {
-                    'id': 'intro',
-                    'type': 'text',
-                    'content': 'Introduction'
-                }
-            ]
-        }
-    })
-    
-    # Create document from JSON
-    doc = BlockDocDocument.from_json(json_str)
-    
-    assert doc.article['title'] == 'Test Document'
-    assert doc.article['metadata']['author'] == 'Test Author'
-    assert len(doc.article['blocks']) == 1
-    assert doc.article['blocks'][0]['id'] == 'intro'
-</file>
-
-<file path="tests/__init__.py">
-# Tests package
+<file path="tests/conversions/test_markdown.py">
+def test_markdown_to_blockdoc_basic()
+⋮----
+markdown = """# Test Document
+doc = markdown_to_blockdoc(markdown)
+⋮----
+def test_markdown_to_blockdoc_with_explicit_title()
+⋮----
+doc = markdown_to_blockdoc(markdown, title="Explicit Title")
+⋮----
+def test_markdown_to_blockdoc_with_metadata()
+⋮----
+metadata = {"author": "Test Author", "tags": ["test", "markdown"]}
+doc = markdown_to_blockdoc(markdown, metadata=metadata)
+⋮----
+def test_markdown_to_blockdoc_blocks()
+⋮----
+markdown = """# Heading 1
+⋮----
+block_types = [block["type"] for block in doc.article["blocks"]]
+⋮----
+headings = [block for block in doc.article["blocks"] if block["type"] == "heading"]
+⋮----
+lists = [block for block in doc.article["blocks"] if block["type"] == "list"]
+list_types = [l["list_type"] for l in lists]
+⋮----
+code_blocks = [block for block in doc.article["blocks"] if block["type"] == "code"]
+⋮----
+quotes = [block for block in doc.article["blocks"] if block["type"] == "quote"]
+⋮----
+def test_empty_markdown()
+⋮----
+doc = markdown_to_blockdoc("")
 </file>
 
 <file path=".gitignore">
@@ -6576,174 +4308,97 @@ htmlcov/
 .DS_Store
 </file>
 
-<file path="CONTRIBUTING.md">
-# Contributing to BlockDoc
+<file path=".pre-commit-config.yaml">
+repos:
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.11
+    hooks:
+    -   id: ruff
+        args: [ --fix ]
+    -   id: ruff-format
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+</file>
 
-Thank you for your interest in contributing to BlockDoc! This document provides guidelines and instructions for contributing to the project.
+<file path="CHANGELOG.md">
+# Changelog
 
-## Table of Contents
+All notable changes to this project will be documented in this file.
 
-1. [Getting Started](#getting-started)
-2. [Development Setup](#development-setup)
-3. [Code Style](#code-style)
-4. [Testing](#testing)
-5. [Documentation](#documentation)
-6. [Pull Request Process](#pull-request-process)
-7. [Issue Reporting](#issue-reporting)
-8. [Feature Requests](#feature-requests)
-9. [Community Guidelines](#community-guidelines)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Getting Started
+## [1.1.0] - 2025-04-25
 
-Before contributing, please:
+### Added
 
-1. Familiarize yourself with the [BlockDoc documentation](docs/)
-2. Check existing [issues](https://github.com/berrydev-ai/blockdoc-python/issues) to see if your issue/feature has been discussed
-3. Check existing [pull requests](https://github.com/berrydev-ai/blockdoc-python/pulls) to avoid duplication
+- New `markdown_to_blockdoc` converter for transforming Markdown documents to BlockDoc format
+- Comprehensive parser that handles all core Markdown elements:
+  - Headings (ATX and Setext styles)
+  - Paragraphs with proper line break handling
+  - Lists (ordered and unordered)
+  - Code blocks with language detection
+  - Block quotes with attribution
+  - Images with captions
+  - Horizontal rules
+- Semantic ID generation based on content
+- Example implementation in `examples/markdown_conversion_example.py`
+- Test suite for the converter functionality
 
-## Development Setup
+## [1.0.1] - 2024-09-15
 
-1. Fork the repository
-2. Clone your fork:
-   ```bash
-   git clone https://github.com/yourusername/blockdoc-python.git
-   cd blockdoc-python
-   ```
-3. Set up the development environment:
-   ```bash
-   # Create a virtual environment
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   
-   # Install development dependencies
-   pip install -e ".[dev]"
-   ```
+### Fixed
+
+- Fixed pyproject.toml syntax error and installation method in CI
+
+## [1.0.0] - 2024-09-01
+
+### Added
+
+- Initial release of BlockDoc
+- Core Block and BlockDocDocument classes
+- HTML and Markdown renderers
+- JSON schema validation
+- Basic utility functions
+</file>
+
+<file path="CLAUDE.md">
+# BlockDoc Project Information
+
+## Development Commands
+
+### Linting and Formatting
+
+- Run linting: `./scripts/lint.sh` or `ruff check .`
+- Run formatting: `./scripts/format.sh` or `ruff format .`
+- Install dev dependencies: `pip install -e ".[dev]"`
+
+### Testing
+
+- Run tests: `pytest` or `pytest tests/`
 
 ## Code Style
 
-BlockDoc follows [PEP 8](https://www.python.org/dev/peps/pep-0008/) with a few customizations:
-
+This project uses ruff for code style enforcement with the following settings:
 - Line length: 88 characters
-- Use docstrings for all public modules, functions, classes, and methods
-- Type hints are encouraged for all functions
-- Black and isort are used for formatting
+- Use double quotes for strings
+- Follow black-compatible formatting
 
-To check and fix code style:
+## Project Structure
 
-```bash
-# Run linting
-flake8 blockdoc tests
-
-# Run formatters
-black blockdoc tests
-isort blockdoc tests
-```
-
-## Testing
-
-We use pytest for testing. All new features should include tests, and bug fixes should include regression tests.
-
-To run tests:
-
-```bash
-# Run all tests
-pytest
-
-# Run tests with coverage report
-pytest --cov=blockdoc
-
-# Run a specific test file
-pytest tests/core/test_block.py
-```
-
-### Test Guidelines
-
-1. Test files should be named `test_*.py`
-2. Test functions should start with `test_`
-3. Each test should be focused and test one specific behavior
-4. Use fixtures where appropriate
-5. Mock external services
-
-## Documentation
-
-Good documentation is crucial for BlockDoc. All new features should include:
-
-1. Docstrings for all public API elements
-2. Updates to relevant documentation files in the `docs/` directory
-3. Example usage where appropriate
-
-For docstrings, we follow the [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings):
-
-```python
-def example_function(param1, param2):
-    """Short description of function.
-    
-    Longer description with more details about behavior,
-    edge cases, etc.
-    
-    Args:
-        param1 (type): Description of param1.
-        param2 (type): Description of param2.
-        
-    Returns:
-        type: Description of return value.
-        
-    Raises:
-        ExceptionType: When and why this exception is raised.
-    """
-    # Implementation
-```
-
-## Pull Request Process
-
-1. **Fork & Branch**: Create a branch in your fork for your contribution
-2. **Implementation**: Make your changes, following code style and including tests
-3. **Documentation**: Update documentation as needed
-4. **Pull Request**: Submit a PR with a clear description:
-   - What problem does it solve?
-   - How was it tested?
-   - Any breaking changes?
-5. **Code Review**: Respond to any feedback from maintainers
-6. **CI**: Ensure all CI checks pass
-
-### PR Title and Description Guidelines
-
-- Use clear, descriptive titles
-- Reference any related issues using GitHub keywords (e.g., "Fixes #123")
-- Describe what changes were made and why
-
-## Issue Reporting
-
-When reporting issues, please:
-
-1. Check existing issues to avoid duplicates
-2. Use the issue templates when available
-3. Include clear reproduction steps
-4. Mention your environment (Python version, OS, BlockDoc version)
-5. Include any error messages or stack traces
-
-## Feature Requests
-
-For feature requests:
-
-1. Clearly describe the problem the feature would solve
-2. Suggest an approach if you have one in mind
-3. Indicate if you're willing to help implement it
-
-## Community Guidelines
-
-We strive to maintain a welcoming and inclusive community. Please:
-
-- Be respectful and considerate of others
-- Focus on constructive feedback
-- Be open to different viewpoints and experiences
-- Gracefully accept constructive criticism
-
-## License
-
-By contributing to BlockDoc, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).
-
-Thank you for contributing to BlockDoc!
+- `blockdoc/`: Main package source code
+  - `core/`: Core functionality (Block and Document classes)
+  - `renderers/`: HTML and Markdown renderers
+  - `schema/`: JSON schema for BlockDoc
+  - `utils/`: Utility functions
+- `tests/`: Test suite
+- `examples/`: Example applications
+- `docs/`: Documentation
 </file>
 
 <file path="LICENSE">
@@ -6781,58 +4436,430 @@ recursive-include examples *.py
 recursive-include tests *.py
 </file>
 
-<file path=".github/workflows/python-lint.yml">
-name: Python Linting
+<file path="blockdoc/api/__init__.py">
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install .[dev]
-    
-    - name: Lint with flake8
-      run: |
-        flake8 blockdoc tests
-    
-    - name: Check formatting with black
-      run: |
-        black --check blockdoc tests
-    
-    - name: Type check with mypy
-      run: |
-        mypy blockdoc
 </file>
 
-<file path="blockdoc/__init__.py">
-"""
-BlockDoc
+<file path="blockdoc/conversions/markdown.py">
+metadata = {}
+doc = BlockDocDocument({"title": title, "metadata": metadata})
+⋮----
+first_line = markdown_text.strip().split("\n")[0]
+⋮----
+extracted_title = first_line[2:].strip()
+⋮----
+markdown_text = "\n".join(markdown_text.strip().split("\n")[1:]).strip()
+blocks = split_markdown_into_blocks(markdown_text)
+⋮----
+blockdoc_block = convert_block_to_blockdoc(block)
+⋮----
+def split_markdown_into_blocks(markdown_text: str) -> List[Dict[str, str]]
+⋮----
+lines = markdown_text.split("\n")
+blocks = []
+current_block = None
+in_code_block = False
+code_lang = ""
+in_list = False
+list_items = []
+list_type = ""
+current_list_indent = 0
+in_quote = False
+quote_lines = []
+quote_has_attribution = False
+i = 0
+⋮----
+line = lines[i]
+stripped_line = line.strip()
+⋮----
+in_code_block = True
+code_lang = stripped_line[3:].strip() or "plain"
+current_block = {"type": "code", "content": "", "language": code_lang}
+⋮----
+heading_match = re.match(r"^(#{1,6})\s+(.+)$", stripped_line)
+⋮----
+level = len(heading_match.group(1))
+content = heading_match.group(2).strip()
+⋮----
+next_line = lines[i + 1].strip()
+⋮----
+content = current_block["content"].strip()
+⋮----
+image_match = re.match(r"^!\[([^\]]*)\]\(([^)]+)\)(?:\s*(.*))?$", stripped_line)
+⋮----
+alt_text = image_match.group(1) or ""
+url = image_match.group(2)
+caption = image_match.group(3) or None
+img_block = {"type": "image", "content": "", "url": url, "alt": alt_text}
+⋮----
+quote_line = stripped_line[1:].strip()
+attribution_match = re.match(r"^[\u2014-]\s+(.+)$", quote_line)
+⋮----
+in_quote = True
+⋮----
+quote_has_attribution = True
+attribution = attribution_match.group(1)
+⋮----
+quote_content = "\n".join(quote_lines).strip()
+quote_block = {"type": "quote", "content": quote_content}
+⋮----
+# Handle lists
+list_match = re.match(r"^(\s*)([-*+]|\d+\.)\s+(.+)$", stripped_line)
+⋮----
+indent = len(list_match.group(1))
+marker = list_match.group(2)
+item_content = list_match.group(3)
+is_ordered = bool(re.match(r"\d+\.", marker))
+⋮----
+# Start of a new list
+⋮----
+in_list = True
+current_list_indent = indent
+list_items = [item_content]
+list_type = "ordered" if is_ordered else "unordered"
+⋮----
+# Continuing a list
+# Check if this is a new list (different indent or type)
+⋮----
+# Different list - end current one and start new
+⋮----
+# Same list - add item
+⋮----
+# Empty line - check if next non-empty line continues the list
+next_i = i + 1
+⋮----
+next_line = lines[next_i]
+next_match = re.match(r"^(\s*)([-*+]|\d+\.)\s+(.+)$", next_line)
+⋮----
+# Next line continues this list after blank line(s)
+i = next_i
+⋮----
+# End of list
+⋮----
+# Not a list item - end list and process line again
+⋮----
+# Don't increment i, process this line again
+⋮----
+current_block = {"type": "text", "content": stripped_line}
+⋮----
+# Add a space unless the line was actually empty
+⋮----
+# This is an empty line within a text block (preserve it)
+⋮----
+# Handle unclosed blocks
+⋮----
+# Unclosed code block - best effort to add it
+⋮----
+def convert_block_to_blockdoc(block: Dict[str, str]) -> Optional[Block]
+⋮----
+block_type = block.get("type")
+# Generate a semantic ID based on content
+block_id = generate_block_id(block)
+⋮----
+content = block.get("content", "").strip()
+if not content:  # Skip empty text blocks
+⋮----
+level = block.get("level", 2)
+⋮----
+language = block.get("language", "plain")
+⋮----
+url = block.get("url", "")
+alt = block.get("alt", "")
+caption = block.get("caption")
+⋮----
+items = block.get("items", [])
+list_type = block.get("list_type", "unordered")
+⋮----
+attribution = block.get("attribution")
+⋮----
+# Unknown block type, convert to text
+⋮----
+# If anything goes wrong, return None
+⋮----
+def generate_block_id(block: Dict[str, str]) -> str
+⋮----
+# For headings, create an ID from the content
+⋮----
+# Convert to lowercase, replace spaces with hyphens, remove non-alphanumeric
+slug = re.sub(r"[^\w\s-]", "", content.lower())
+slug = re.sub(r"[\s-]+", "-", slug).strip("-")
+return slug[:40]  # Limit length of ID
+# For other block types, use the type as a prefix
+⋮----
+prefix = block_type
+# For specific block types, enhance the ID
+⋮----
+prefix = f"code-{block.get('language')}"
+⋮----
+prefix = f"{block.get('list_type', 'unordered')}-list"
+suffix = str(uuid.uuid4())[:8]
+</file>
 
-A simple, powerful standard for structured content that works beautifully with LLMs, humans, and modern editors.
-"""
+<file path="blockdoc/core/__init__.py">
 
-from blockdoc.core.block import Block
-from blockdoc.core.document import BlockDocDocument
-from blockdoc.renderers.html import render_to_html
-from blockdoc.renderers.markdown import render_to_markdown
-from blockdoc.schema.loader import schema
+</file>
 
-__version__ = '1.0.1'
+<file path="blockdoc/core/block.py">
+ALLOWED_TYPES = [
+TYPE_REQUIREMENTS = {
+class Block
+⋮----
+def __init__(self, data)
+⋮----
+required_props = TYPE_REQUIREMENTS.get(self.type, [])
+⋮----
+python_prop = prop
+⋮----
+python_prop = "list_type"
+⋮----
+def update(self, updates)
+⋮----
+updates_copy = updates.copy()
+⋮----
+def to_dict(self)
+⋮----
+result = {
+⋮----
+@classmethod
+    def text(cls, id, content)
+⋮----
+@classmethod
+    def heading(cls, id, level, content)
+⋮----
+@classmethod
+    def image(cls, id, url, alt, caption=None)
+⋮----
+data = {
+⋮----
+@classmethod
+    def code(cls, id, language, content)
+⋮----
+@classmethod
+    def list(cls, id, items, list_type="unordered")
+⋮----
+@classmethod
+    def quote(cls, id, content, attribution=None)
+⋮----
+@classmethod
+    def embed(cls, id, url, embed_type, caption=None)
+⋮----
+@classmethod
+    def divider(cls, id)
+</file>
+
+<file path="blockdoc/core/document.py">
+class BlockDocDocument
+⋮----
+def __init__(self, options)
+⋮----
+title = options.get("title")
+metadata = options.get("metadata", {})
+blocks = options.get("blocks", [])
+⋮----
+def validate(self)
+def add_block(self, block_data)
+⋮----
+block_data = block_data.to_dict()
+# Check if ID already exists
+⋮----
+block = Block(block_data)
+⋮----
+def insert_block(self, block_data, position)
+⋮----
+# If it's already a Block instance, convert to dict
+⋮----
+def get_block(self, id)
+def update_block(self, id, updates)
+⋮----
+index = -1
+⋮----
+index = i
+⋮----
+current_block = self.article["blocks"][index]
+updated_data = {**current_block, **updates}
+block = Block(updated_data)
+⋮----
+def remove_block(self, id)
+def move_block(self, id, new_position)
+⋮----
+block = self.article["blocks"].pop(index)
+⋮----
+def render_to_html(self)
+def render_to_markdown(self)
+def to_dict(self)
+def to_json(self, indent=2)
+⋮----
+@classmethod
+    def from_dict(cls, data)
+⋮----
+article = data["article"]
+⋮----
+@classmethod
+    def from_json(cls, json_str)
+⋮----
+data = json.loads(json_str)
+</file>
+
+<file path="blockdoc/renderers/__init__.py">
+
+</file>
+
+<file path="blockdoc/renderers/html.py">
+def render_to_html(article)
+⋮----
+html = [
+⋮----
+def render_block(block)
+⋮----
+block_id = block.get("id", "")
+block_type = block.get("type", "")
+open_wrapper = f'<div class="blockdoc-block blockdoc-{block_type}" data-block-id="{block_id}" data-block-type="{block_type}">'
+close_wrapper = "</div>"
+⋮----
+content = render_text_block(block)
+⋮----
+content = render_heading_block(block)
+⋮----
+content = render_image_block(block)
+⋮----
+content = render_code_block(block)
+⋮----
+content = render_list_block(block)
+⋮----
+content = render_quote_block(block)
+⋮----
+content = render_embed_block(block)
+⋮----
+content = render_divider_block()
+⋮----
+content = f"<p>Unknown block type: {block_type}</p>"
+⋮----
+def render_text_block(block)
+def render_heading_block(block)
+⋮----
+level = block.get("level", 2)
+content = block.get("content", "")
+valid_level = min(max(int(level), 1), 6)
+⋮----
+def render_image_block(block)
+⋮----
+url = sanitize_url(block.get("url", ""))
+alt = sanitize_html(block.get("alt", ""))
+caption = block.get("caption")
+img_html = f'<img src="{url}" alt="{alt}" class="blockdoc-image" />'
+⋮----
+def render_code_block(block)
+⋮----
+language = block.get("language", "")
+⋮----
+lexer = get_lexer_by_name(language)
+⋮----
+lexer = guess_lexer(content)
+highlighted_code = highlight(content, lexer, HtmlFormatter())
+⋮----
+highlighted_code = sanitize_html(content)
+⋮----
+def render_list_block(block)
+⋮----
+items = block.get("items", [])
+list_type = block.get("list_type", block.get("listType", "unordered"))
+⋮----
+tag = "ol" if list_type == "ordered" else "ul"
+items_html = []
+⋮----
+rendered_item = markdown(item)
+rendered_item = rendered_item.replace("<p>", "").replace("</p>", "")
+⋮----
+def render_quote_block(block)
+⋮----
+attribution = block.get("attribution")
+html = f'<blockquote class="blockdoc-quote">{markdown(content)}</blockquote>'
+⋮----
+def render_embed_block(block)
+⋮----
+embed_type = block.get("embed_type", block.get("embedType", "generic"))
+⋮----
+video_id = extract_youtube_id(url)
+⋮----
+embed_html = f"""
+⋮----
+embed_html = "<p>Invalid YouTube URL</p>"
+⋮----
+def render_divider_block()
+def extract_youtube_id(url)
+⋮----
+youtu_be_match = re.match(r"https?://youtu\.be/([a-zA-Z0-9_-]+)", url)
+⋮----
+youtube_match = re.match(
+</file>
+
+<file path="blockdoc/renderers/markdown.py">
+def render_to_markdown(article)
+⋮----
+markdown = [f"# {article['title']}", ""]
+⋮----
+metadata = article["metadata"]
+⋮----
+date = datetime.fromisoformat(
+⋮----
+def render_block_to_markdown(block)
+⋮----
+block_type = block.get("type", "")
+⋮----
+def render_text_block_to_markdown(block)
+def render_heading_block_to_markdown(block)
+⋮----
+level = block.get("level", 2)
+content = block.get("content", "")
+valid_level = min(max(int(level), 1), 6)
+hashtags = "#" * valid_level
+⋮----
+def render_image_block_to_markdown(block)
+⋮----
+url = block.get("url", "")
+alt = block.get("alt", "")
+caption = block.get("caption")
+markdown = f"![{alt}]({url})"
+⋮----
+def render_code_block_to_markdown(block)
+⋮----
+language = block.get("language", "")
+⋮----
+def render_list_block_to_markdown(block)
+⋮----
+items = block.get("items", [])
+list_type = block.get("list_type", block.get("listType", "unordered"))
+⋮----
+markdown_items = []
+⋮----
+def render_quote_block_to_markdown(block)
+⋮----
+attribution = block.get("attribution")
+markdown = "\n".join([f"> {line}" for line in content.split("\n")])
+⋮----
+def render_embed_block_to_markdown(block)
+⋮----
+embed_type = block.get("embed_type", block.get("embedType", "generic"))
+markdown = f"[{embed_type or 'Embedded content'}: {url}]({url})"
+</file>
+
+<file path="blockdoc/schema/__init__.py">
+
+</file>
+
+<file path="blockdoc/schema/loader.py">
+schema_path = os.path.join(os.path.dirname(__file__), "blockdoc.schema.json")
+⋮----
+schema = json.load(schema_file)
+</file>
+
+<file path="blockdoc/utils/__init__.py">
+
+</file>
+
+<file path="blockdoc/utils/sanitize.py">
+def sanitize_html(html_content)
+def sanitize_url(url)
 </file>
 
 <file path="docs/spec/blockdoc-specification.md">
@@ -7126,31 +5153,536 @@ BlockDoc is particularly well-suited for:
 - **0.5.0** (2025-01-10): Alpha release for testing
 </file>
 
-<file path="pyproject.toml">
-[build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
-build-backend = "setuptools.build_meta"
+<file path="examples/llm-integration/llm_content_generator.py">
+def generate_with_llm(prompt, max_tokens=800)
+def create_article_with_llm(title, topic)
+⋮----
+# Create a new document
+article = BlockDocDocument(
+# Generate introduction
+intro_prompt = f"""Write an engaging introduction for an article titled "{title}" about {topic}.
+intro_content = generate_with_llm(intro_prompt)
+⋮----
+# Generate a section about benefits/features
+⋮----
+benefits_prompt = f"""Create a list of 4-6 key benefits or features of {topic}.
+benefits_content = generate_with_llm(benefits_prompt)
+# Parse the list items from the response
+benefits_items = []
+⋮----
+line = line.strip()
+⋮----
+# Generate a code example section
+⋮----
+code_prompt = f"""Create a Python code example related to {topic} using the BlockDoc library.
+code_content = generate_with_llm(code_prompt)
+# Extract the code from markdown code blocks if present
+⋮----
+code_parts = code_content.split("```")
+⋮----
+# Get the content inside the code block
+code_block = code_parts[1]
+# Remove language identifier if present
+⋮----
+code_block = code_block[code_block.find("\n") + 1 :]
+code_content = code_block.strip()
+⋮----
+# Generate a use cases section
+⋮----
+use_cases_prompt = f"""Describe 4-5 practical use cases for {topic}.
+use_cases_content = generate_with_llm(use_cases_prompt)
+⋮----
+# Add an image placeholder
+⋮----
+# Generate conclusion
+⋮----
+conclusion_prompt = f"""Write a conclusion for an article about {topic}.
+conclusion_content = generate_with_llm(conclusion_prompt)
+⋮----
+def update_block_with_llm(document, block_id, instruction)
+⋮----
+# Get the existing block
+block = document.get_block(block_id)
+⋮----
+block_type = block["type"]
+⋮----
+# Generate updated text content
+prompt = f"""Here is an existing text block:
+updated_content = generate_with_llm(prompt)
+⋮----
+# Generate updated heading
+prompt = f"""Here is an existing heading:
+⋮----
+# Update list items
+items = block.get("items", [])
+items_text = "\n".join([f"- {item}" for item in items])
+prompt = f"""Here is an existing list:
+⋮----
+# Parse updated list items
+updated_items = []
+⋮----
+# Update code content
+prompt = f"""Here is an existing code block in {block.get("language", "python")}:
+⋮----
+# Extract the code from markdown code blocks if present
+⋮----
+code_parts = updated_content.split("```")
+⋮----
+# Get the content inside the code block
+⋮----
+# Remove language identifier if present
+⋮----
+updated_content = code_block.strip()
+⋮----
+def main()
+⋮----
+parser = argparse.ArgumentParser(
+⋮----
+args = parser.parse_args()
+# Create output directory if it doesn't exist
+⋮----
+# Update an existing document
+⋮----
+document = BlockDocDocument.from_json(f.read())
+⋮----
+document = update_block_with_llm(document, args.block_id, args.instruction)
+# Save the updated document
+output_file = os.path.basename(args.input)
+updated_path = os.path.join(args.output_dir, f"updated_{output_file}")
+⋮----
+# Also save HTML for preview
+html_path = os.path.join(
+⋮----
+# Create a new document
+⋮----
+document = create_article_with_llm(args.title, args.topic)
+# Validate the document
+⋮----
+# Create a slug from the title for filenames
+slug = args.title.lower().replace(" ", "-")
+slug = "".join(c for c in slug if c.isalnum() or c == "-")
+# Save as JSON
+json_path = os.path.join(args.output_dir, f"{slug}.json")
+⋮----
+# Save as HTML
+html_path = os.path.join(args.output_dir, f"{slug}.html")
+⋮----
+html = f"""<!DOCTYPE html>
+⋮----
+# Save as Markdown
+md_path = os.path.join(args.output_dir, f"{slug}.md")
+⋮----
+frontmatter = f"""---
+</file>
 
-[tool.black]
-line-length = 88
-target-version = ['py37']
-include = '\.pyi?$'
+<file path="examples/simple-blog/blog_generator.py">
+def create_blog_post(title, author, content_json=None)
+⋮----
+blog_post = BlockDocDocument(
+⋮----
+content_structure = json.load(f)
+⋮----
+block_type = item.get("type")
+block_id = item.get("id")
+⋮----
+def main()
+⋮----
+parser = argparse.ArgumentParser(description="Generate a blog post using BlockDoc")
+⋮----
+args = parser.parse_args()
+⋮----
+# Create the blog post
+⋮----
+blog_post = create_blog_post(args.title, args.author, args.content)
+# Validate the document
+⋮----
+# Create a slug from the title for filenames
+slug = args.title.lower().replace(" ", "-")
+slug = "".join(c for c in slug if c.isalnum() or c == "-")
+# Save as JSON
+json_path = os.path.join(args.output_dir, f"{slug}.json")
+⋮----
+# Render to HTML
+html_path = os.path.join(args.output_dir, f"{slug}.html")
+⋮----
+# Add basic styling
+html = """<!DOCTYPE html>
+⋮----
+md_path = os.path.join(args.output_dir, f"{slug}.md")
+⋮----
+frontmatter = f"""---
+</file>
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
+<file path="examples/basic_example.py">
+def create_blog_post()
+⋮----
+blog_post = BlockDocDocument(
+⋮----
+quote_block = Block(
+⋮----
+def main()
+⋮----
+blog_post = create_blog_post()
+⋮----
+output_dir = os.path.join(os.path.dirname(__file__), "output")
+⋮----
+html = blog_post.render_to_html()
+⋮----
+markdown = blog_post.render_to_markdown()
+</file>
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = "test_*.py"
-addopts = "--cov=blockdoc"
+<file path="scripts/format.sh">
+echo "Running Ruff formatter..."
+ruff format blockdoc tests examples
+echo "Done!"
+</file>
 
-[tool.mypy]
-python_version = "3.7"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
+<file path="scripts/lint.sh">
+echo "Running Ruff linter..."
+ruff check blockdoc tests examples
+echo "Running Ruff formatter..."
+ruff format blockdoc tests examples
+echo "Running mypy type checking..."
+mypy blockdoc
+echo "Done!"
+</file>
+
+<file path="tests/core/__init__.py">
+
+</file>
+
+<file path="tests/core/test_block.py">
+def test_block_init()
+⋮----
+text_block = Block({"id": "intro", "type": "text", "content": "Hello world"})
+⋮----
+heading_block = Block(
+⋮----
+def test_block_init_missing_id()
+def test_block_init_invalid_type()
+def test_block_init_missing_required_props()
+def test_block_update()
+⋮----
+block = Block({"id": "intro", "type": "text", "content": "Hello world"})
+⋮----
+def test_block_to_dict()
+⋮----
+block_data = {"id": "intro", "type": "text", "content": "Hello world"}
+block = Block(block_data)
+result = block.to_dict()
+⋮----
+def test_block_factory_methods()
+⋮----
+text_block = Block.text("intro", "Hello world")
+⋮----
+heading_block = Block.heading("title", 1, "Title")
+⋮----
+image_block = Block.image(
+⋮----
+code_block = Block.code("snippet", "javascript", 'console.log("Hello");')
+⋮----
+list_block = Block.list("items", ["Item 1", "Item 2"], "ordered")
+⋮----
+quote_block = Block.quote("quote", "Famous quote", "Famous person")
+⋮----
+embed_block = Block.embed(
+⋮----
+divider_block = Block.divider("separator")
+</file>
+
+<file path="tests/__init__.py">
+
+</file>
+
+<file path="CONTRIBUTING.md">
+# Contributing to BlockDoc
+
+Thank you for your interest in contributing to BlockDoc! This document provides guidelines and instructions for contributing to the project.
+
+## Table of Contents
+
+1. [Getting Started](#getting-started)
+2. [Development Setup](#development-setup)
+3. [Code Style](#code-style)
+4. [Testing](#testing)
+5. [Documentation](#documentation)
+6. [Pull Request Process](#pull-request-process)
+7. [Issue Reporting](#issue-reporting)
+8. [Feature Requests](#feature-requests)
+9. [Community Guidelines](#community-guidelines)
+
+## Getting Started
+
+Before contributing, please:
+
+1. Familiarize yourself with the [BlockDoc documentation](docs/)
+2. Check existing [issues](https://github.com/berrydev-ai/blockdoc-python/issues) to see if your issue/feature has been discussed
+3. Check existing [pull requests](https://github.com/berrydev-ai/blockdoc-python/pulls) to avoid duplication
+
+## Development Setup
+
+1. Fork the repository
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/yourusername/blockdoc-python.git
+   cd blockdoc-python
+   ```
+3. Set up the development environment:
+   ```bash
+   # Create a virtual environment
+   python -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   
+   # Install development dependencies
+   pip install -e ".[dev]"
+   ```
+
+## Code Style
+
+BlockDoc follows [PEP 8](https://www.python.org/dev/peps/pep-0008/) with a few customizations:
+
+- Line length: 88 characters
+- Use docstrings for all public modules, functions, classes, and methods
+- Type hints are encouraged for all functions
+- Ruff is used for linting and formatting (compatible with Black style)
+
+To check and fix code style:
+
+```bash
+# Run linting
+ruff check blockdoc tests
+
+# Run formatting
+ruff format blockdoc tests
+
+# Or use the provided scripts
+./scripts/lint.sh
+./scripts/format.sh
+```
+
+## Testing
+
+We use pytest for testing. All new features should include tests, and bug fixes should include regression tests.
+
+To run tests:
+
+```bash
+# Run all tests
+pytest
+
+# Run tests with coverage report
+pytest --cov=blockdoc
+
+# Run a specific test file
+pytest tests/core/test_block.py
+```
+
+### Test Guidelines
+
+1. Test files should be named `test_*.py`
+2. Test functions should start with `test_`
+3. Each test should be focused and test one specific behavior
+4. Use fixtures where appropriate
+5. Mock external services
+
+## Documentation
+
+Good documentation is crucial for BlockDoc. All new features should include:
+
+1. Docstrings for all public API elements
+2. Updates to relevant documentation files in the `docs/` directory
+3. Example usage where appropriate
+
+For docstrings, we follow the [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings):
+
+```python
+def example_function(param1, param2):
+    """Short description of function.
+    
+    Longer description with more details about behavior,
+    edge cases, etc.
+    
+    Args:
+        param1 (type): Description of param1.
+        param2 (type): Description of param2.
+        
+    Returns:
+        type: Description of return value.
+        
+    Raises:
+        ExceptionType: When and why this exception is raised.
+    """
+    # Implementation
+```
+
+## Pull Request Process
+
+1. **Fork & Branch**: Create a branch in your fork for your contribution
+2. **Implementation**: Make your changes, following code style and including tests
+3. **Documentation**: Update documentation as needed
+4. **Pull Request**: Submit a PR with a clear description:
+   - What problem does it solve?
+   - How was it tested?
+   - Any breaking changes?
+5. **Code Review**: Respond to any feedback from maintainers
+6. **CI**: Ensure all CI checks pass
+
+### PR Title and Description Guidelines
+
+- Use clear, descriptive titles
+- Reference any related issues using GitHub keywords (e.g., "Fixes #123")
+- Describe what changes were made and why
+
+## Issue Reporting
+
+When reporting issues, please:
+
+1. Check existing issues to avoid duplicates
+2. Use the issue templates when available
+3. Include clear reproduction steps
+4. Mention your environment (Python version, OS, BlockDoc version)
+5. Include any error messages or stack traces
+
+## Feature Requests
+
+For feature requests:
+
+1. Clearly describe the problem the feature would solve
+2. Suggest an approach if you have one in mind
+3. Indicate if you're willing to help implement it
+
+## Community Guidelines
+
+We strive to maintain a welcoming and inclusive community. Please:
+
+- Be respectful and considerate of others
+- Focus on constructive feedback
+- Be open to different viewpoints and experiences
+- Gracefully accept constructive criticism
+
+## License
+
+By contributing to BlockDoc, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).
+
+Thank you for contributing to BlockDoc!
+</file>
+
+<file path=".github/workflows/python-lint.yml">
+name: Python Linting
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[dev]
+    - name: Lint and check formatting with ruff
+      run: |
+        ruff check blockdoc tests examples
+        ruff format --check blockdoc tests examples
+    - name: Type check with mypy
+      run: |
+        mypy blockdoc
+</file>
+
+<file path=".github/workflows/python-tests.yml">
+name: Python Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[dev]
+    - name: Run tests with pytest
+      run: |
+        python -m pytest --cov=blockdoc
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: false
+</file>
+
+<file path="tests/core/test_document.py">
+def test_document_init()
+⋮----
+doc = BlockDocDocument({"title": "Test Document"})
+⋮----
+doc = BlockDocDocument(
+⋮----
+def test_document_init_missing_title()
+def test_document_add_block()
+⋮----
+block = doc.add_block({"id": "intro", "type": "text", "content": "Introduction"})
+⋮----
+heading_block = Block.heading("heading", 2, "Section")
+⋮----
+def test_document_insert_block()
+def test_document_get_block()
+⋮----
+block = doc.get_block("intro")
+⋮----
+block = doc.get_block("nonexistent")
+⋮----
+def test_document_update_block()
+⋮----
+updated_block = doc.update_block("intro", {"content": "Updated introduction"})
+⋮----
+def test_document_remove_block()
+⋮----
+result = doc.remove_block("intro")
+⋮----
+result = doc.remove_block("nonexistent")
+⋮----
+def test_document_move_block()
+⋮----
+result = doc.move_block("conclusion", 0)
+⋮----
+result = doc.move_block("nonexistent", 0)
+⋮----
+def test_document_to_dict()
+⋮----
+result = doc.to_dict()
+⋮----
+def test_document_to_json()
+⋮----
+json_str = doc.to_json()
+data = json.loads(json_str)
+⋮----
+def test_document_from_dict()
+⋮----
+data = {
+doc = BlockDocDocument.from_dict(data)
+⋮----
+def test_document_from_json()
+⋮----
+json_str = json.dumps(
+doc = BlockDocDocument.from_json(json_str)
 </file>
 
 <file path="README.md">
@@ -7360,6 +5892,10 @@ pytest --cov=blockdoc
 
 # Run a specific test file
 pytest tests/core/test_block.py
+
+# Run linting and formatting with ruff
+ruff check .
+ruff format .
 ```
 
 ## Contributing
@@ -7371,110 +5907,57 @@ We welcome contributions! See [CONTRIBUTING.md](https://github.com/berrydev-ai/b
 [MIT](https://github.com/berrydev-ai/blockdoc-python/blob/main/LICENSE)
 </file>
 
-<file path=".github/workflows/python-tests.yml">
-name: Python Tests
+<file path="pyproject.toml">
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+[tool.ruff]
+target-version = "py37"
+line-length = 88
+exclude = [
+    ".git",
+    ".ruff_cache",
+    "__pycache__",
+    "build",
+    "dist",
+]
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
+[tool.ruff.lint]
+# Enable pycodestyle (E), Pyflakes (F), isort (I), and more
+select = ["E", "F", "I", "W", "N", "UP", "B", "C4", "SIM", "ERA"]
+ignore = ["E203"]
 
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install .[dev]
-    
-    - name: Run tests with pytest
-      run: |
-        python -m pytest --cov=blockdoc
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        fail_ci_if_error: false
+[tool.ruff.lint.isort]
+known-first-party = ["blockdoc"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+addopts = "--cov=blockdoc"
+
+[tool.mypy]
+python_version = "3.7"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+</file>
+
+<file path="blockdoc/__init__.py">
+__all__ = [
+__version__ = "1.1.0"
 </file>
 
 <file path="setup.py">
-from setuptools import setup, find_packages
-import os
-
-# Read the contents of README.md
 this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-setup(
-    name="blockdoc",
-    version="1.0.1",
-    author="Eric Berry",
-    author_email="eric@berrydev.ai",
-    description="A simple, powerful standard for structured content that works beautifully with LLMs, humans, and modern editors",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/berrydev-ai/blockdoc-python",
-    packages=find_packages(),
-    include_package_data=True,
-    package_data={
-        'blockdoc': ['schema/*.json'],
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Text Processing :: Markup",
-    ],
-    python_requires=">=3.7",
-    install_requires=[
-        "markdown>=3.3.0",
-        "pygments>=2.10.0",
-        "jsonschema>=4.0.0",
-    ],
-    extras_require={
-        "dev": [
-            "pytest>=7.0.0",
-            "pytest-cov>=4.0.0",
-            "black>=23.0.0",
-            "flake8>=6.0.0",
-            "mypy>=1.0.0",
-            "twine>=4.0.0",
-        ],
-    },
-    keywords=[
-        "content",
-        "cms",
-        "llm",
-        "markdown",
-        "structured-content",
-        "editor",
-        "blocks",
-        "document",
-        "ai",
-    ],
-)
+⋮----
+long_description = f.read()
 </file>
 
 </files>

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,31 @@
+{
+  "output": {
+    "filePath": "repomix-output.xml",
+    "style": "xml",
+    "parsableStyle": false,
+    "fileSummary": true,
+    "directoryStructure": true,
+    "removeComments": true,
+    "removeEmptyLines": true,
+    "compress": true,
+    "topFilesLength": 5,
+    "showLineNumbers": false,
+    "copyToClipboard": false,
+    "git": {
+      "sortByChanges": true,
+      "sortByChangesMaxCommits": 100
+    }
+  },
+  "include": [],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": []
+  },
+  "security": {
+    "enableSecurityCheck": true
+  },
+  "tokenCount": {
+    "encoding": "o200k_base"
+  }
+}

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,6 +2,6 @@
 
 # Run ruff formatter on the codebase
 echo "Running Ruff formatter..."
-ruff format .
+ruff format blockdoc tests examples
 
 echo "Done!"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,11 +2,11 @@
 
 # Run ruff linting checks
 echo "Running Ruff linter..."
-ruff check .
+ruff check blockdoc tests examples
 
 # Run ruff formatting
 echo "Running Ruff formatter..."
-ruff format .
+ruff format blockdoc tests examples
 
 # Check for mypy type errors
 echo "Running mypy type checking..."

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Run ruff linting checks
+# Run ruff linting checks with auto-fix
 echo "Running Ruff linter..."
-ruff check blockdoc tests examples
+ruff check --fix blockdoc tests examples
 
 # Run ruff formatting
 echo "Running Ruff formatter..."

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,6 @@ setup(
             "ruff>=0.1.0",
             "mypy>=1.0.0",
             "twine>=4.0.0",
-            "flake8>=6.0.0",
-            "black>=23.0.0",
         ],
     },
     keywords=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Text Processing :: Markup",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "markdown>=3.3.0",
         "pygments>=2.10.0",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
             "ruff>=0.1.0",
             "mypy>=1.0.0",
             "twine>=4.0.0",
+            "flake8>=6.0.0",
+            "black>=23.0.0",
         ],
     },
     keywords=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="blockdoc",
-    version="1.0.1",
+    version="1.1.0",
     author="Eric Berry",
     author_email="eric@berrydev.ai",
     description="A simple, powerful standard for structured content that works beautifully with LLMs, humans, and modern editors",

--- a/tests/conversions/test_markdown.py
+++ b/tests/conversions/test_markdown.py
@@ -1,6 +1,7 @@
 """
 Test the Markdown to BlockDoc converter
 """
+
 import pytest
 
 from blockdoc.conversions.markdown import markdown_to_blockdoc
@@ -13,9 +14,9 @@ def test_markdown_to_blockdoc_basic():
     
 This is a paragraph with **bold** and *italic* text.
     """
-    
+
     doc = markdown_to_blockdoc(markdown)
-    
+
     assert isinstance(doc, BlockDocDocument)
     assert doc.article["title"] == "Test Document"
     assert len(doc.article["blocks"]) == 1
@@ -29,9 +30,9 @@ def test_markdown_to_blockdoc_with_explicit_title():
     
 This is a paragraph.
     """
-    
+
     doc = markdown_to_blockdoc(markdown, title="Explicit Title")
-    
+
     assert doc.article["title"] == "Explicit Title"
 
 
@@ -41,14 +42,11 @@ def test_markdown_to_blockdoc_with_metadata():
     
 This is a paragraph.
     """
-    
-    metadata = {
-        "author": "Test Author",
-        "tags": ["test", "markdown"]
-    }
-    
+
+    metadata = {"author": "Test Author", "tags": ["test", "markdown"]}
+
     doc = markdown_to_blockdoc(markdown, metadata=metadata)
-    
+
     assert doc.article["metadata"]["author"] == "Test Author"
     assert "test" in doc.article["metadata"]["tags"]
 
@@ -82,15 +80,15 @@ def test():
 
 Final paragraph.
 """
-    
+
     doc = markdown_to_blockdoc(markdown)
-    
+
     # Check number of blocks (should have 9 blocks)
     assert len(doc.article["blocks"]) == 9
-    
+
     # Extract block types
     block_types = [block["type"] for block in doc.article["blocks"]]
-    
+
     # Check that we have all the expected block types
     assert "heading" in block_types
     assert "text" in block_types
@@ -99,21 +97,21 @@ Final paragraph.
     assert "quote" in block_types
     assert "image" in block_types
     assert "divider" in block_types
-    
+
     # Check heading levels
     headings = [block for block in doc.article["blocks"] if block["type"] == "heading"]
     assert any(h["level"] == 2 for h in headings)
-    
+
     # Check list types
     lists = [block for block in doc.article["blocks"] if block["type"] == "list"]
     list_types = [l["list_type"] for l in lists]
     assert "ordered" in list_types
     assert "unordered" in list_types
-    
+
     # Check code block language
     code_blocks = [block for block in doc.article["blocks"] if block["type"] == "code"]
     assert code_blocks[0]["language"] == "python"
-    
+
     # Check quote attribution
     quotes = [block for block in doc.article["blocks"] if block["type"] == "quote"]
     assert "Attribution" in quotes[0]["attribution"]
@@ -122,6 +120,6 @@ Final paragraph.
 def test_empty_markdown():
     """Test conversion of empty markdown"""
     doc = markdown_to_blockdoc("")
-    
+
     assert doc.article["title"] == "Untitled Document"
     assert len(doc.article["blocks"]) == 0

--- a/tests/conversions/test_markdown.py
+++ b/tests/conversions/test_markdown.py
@@ -1,0 +1,127 @@
+"""
+Test the Markdown to BlockDoc converter
+"""
+import pytest
+
+from blockdoc.conversions.markdown import markdown_to_blockdoc
+from blockdoc.core.document import BlockDocDocument
+
+
+def test_markdown_to_blockdoc_basic():
+    """Test basic markdown conversion"""
+    markdown = """# Test Document
+    
+This is a paragraph with **bold** and *italic* text.
+    """
+    
+    doc = markdown_to_blockdoc(markdown)
+    
+    assert isinstance(doc, BlockDocDocument)
+    assert doc.article["title"] == "Test Document"
+    assert len(doc.article["blocks"]) == 1
+    assert doc.article["blocks"][0]["type"] == "text"
+    assert "bold" in doc.article["blocks"][0]["content"]
+
+
+def test_markdown_to_blockdoc_with_explicit_title():
+    """Test markdown conversion with explicit title"""
+    markdown = """# Test Document
+    
+This is a paragraph.
+    """
+    
+    doc = markdown_to_blockdoc(markdown, title="Explicit Title")
+    
+    assert doc.article["title"] == "Explicit Title"
+
+
+def test_markdown_to_blockdoc_with_metadata():
+    """Test markdown conversion with metadata"""
+    markdown = """# Test Document
+    
+This is a paragraph.
+    """
+    
+    metadata = {
+        "author": "Test Author",
+        "tags": ["test", "markdown"]
+    }
+    
+    doc = markdown_to_blockdoc(markdown, metadata=metadata)
+    
+    assert doc.article["metadata"]["author"] == "Test Author"
+    assert "test" in doc.article["metadata"]["tags"]
+
+
+def test_markdown_to_blockdoc_blocks():
+    """Test conversion of different markdown block types"""
+    markdown = """# Heading 1
+
+## Heading 2
+
+This is a paragraph.
+
+- List item 1
+- List item 2
+
+1. Ordered item 1
+2. Ordered item 2
+
+```python
+def test():
+    pass
+```
+
+> This is a quote
+> Multiple lines
+> — Attribution
+
+![Alt text](https://example.com/image.jpg) Caption
+
+---
+
+Final paragraph.
+"""
+    
+    doc = markdown_to_blockdoc(markdown)
+    
+    # Check number of blocks (should have 9 blocks)
+    assert len(doc.article["blocks"]) == 9
+    
+    # Extract block types
+    block_types = [block["type"] for block in doc.article["blocks"]]
+    
+    # Check that we have all the expected block types
+    assert "heading" in block_types
+    assert "text" in block_types
+    assert "list" in block_types
+    assert "code" in block_types
+    assert "quote" in block_types
+    assert "image" in block_types
+    assert "divider" in block_types
+    
+    # Check heading levels
+    headings = [block for block in doc.article["blocks"] if block["type"] == "heading"]
+    assert any(h["level"] == 2 for h in headings)
+    
+    # Check list types
+    lists = [block for block in doc.article["blocks"] if block["type"] == "list"]
+    list_types = [l["list_type"] for l in lists]
+    assert "ordered" in list_types
+    assert "unordered" in list_types
+    
+    # Check code block language
+    code_blocks = [block for block in doc.article["blocks"] if block["type"] == "code"]
+    assert code_blocks[0]["language"] == "python"
+    
+    # Check quote attribution
+    quotes = [block for block in doc.article["blocks"] if block["type"] == "quote"]
+    assert "Attribution" in quotes[0]["attribution"]
+
+
+def test_empty_markdown():
+    """Test conversion of empty markdown"""
+    doc = markdown_to_blockdoc("")
+    
+    assert doc.article["title"] == "Untitled Document"
+    assert len(doc.article["blocks"]) == 0

--- a/tests/conversions/test_markdown.py
+++ b/tests/conversions/test_markdown.py
@@ -2,8 +2,6 @@
 Test the Markdown to BlockDoc converter
 """
 
-import pytest
-
 from blockdoc.conversions.markdown import markdown_to_blockdoc
 from blockdoc.core.document import BlockDocDocument
 

--- a/tests/core/test_block.py
+++ b/tests/core/test_block.py
@@ -16,9 +16,7 @@ def test_block_init():
     assert text_block.content == "Hello world"
 
     # Test heading block
-    heading_block = Block(
-        {"id": "title", "type": "heading", "level": 1, "content": "Title"}
-    )
+    heading_block = Block({"id": "title", "type": "heading", "level": 1, "content": "Title"})
     assert heading_block.id == "title"
     assert heading_block.type == "heading"
     assert heading_block.level == 1
@@ -57,9 +55,7 @@ def test_block_init_missing_required_props():
     # Image without url and alt
     with pytest.raises(ValueError) as excinfo:
         Block({"id": "image", "type": "image", "content": ""})
-    assert "requires property" in str(excinfo.value) and (
-        "url" in str(excinfo.value) or "alt" in str(excinfo.value)
-    )
+    assert "requires property" in str(excinfo.value) and ("url" in str(excinfo.value) or "alt" in str(excinfo.value))
 
 
 def test_block_update():
@@ -103,9 +99,7 @@ def test_block_factory_methods():
     assert heading_block.content == "Title"
 
     # Image block
-    image_block = Block.image(
-        "hero", "https://example.com/image.jpg", "Alt text", "Caption"
-    )
+    image_block = Block.image("hero", "https://example.com/image.jpg", "Alt text", "Caption")
     assert image_block.id == "hero"
     assert image_block.type == "image"
     assert image_block.url == "https://example.com/image.jpg"
@@ -134,9 +128,7 @@ def test_block_factory_methods():
     assert quote_block.attribution == "Famous person"
 
     # Embed block
-    embed_block = Block.embed(
-        "video", "https://youtube.com/watch?v=123", "youtube", "Video caption"
-    )
+    embed_block = Block.embed("video", "https://youtube.com/watch?v=123", "youtube", "Video caption")
     assert embed_block.id == "video"
     assert embed_block.type == "embed"
     assert embed_block.url == "https://youtube.com/watch?v=123"

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -75,9 +75,7 @@ def test_document_add_block():
 
     # Try adding a block with existing ID
     with pytest.raises(ValueError) as excinfo:
-        doc.add_block(
-            {"id": "intro", "type": "text", "content": "New introduction"}
-        )
+        doc.add_block({"id": "intro", "type": "text", "content": "New introduction"})
     assert "Block with ID 'intro' already exists" in str(excinfo.value)
 
 
@@ -124,9 +122,7 @@ def test_document_update_block():
     doc.add_block(Block.text("intro", "Introduction"))
 
     # Update the block
-    updated_block = doc.update_block(
-        "intro", {"content": "Updated introduction"}
-    )
+    updated_block = doc.update_block("intro", {"content": "Updated introduction"})
 
     assert updated_block["content"] == "Updated introduction"
     assert doc.article["blocks"][0]["content"] == "Updated introduction"
@@ -219,9 +215,7 @@ def test_document_from_dict():
         "article": {
             "title": "Test Document",
             "metadata": {"author": "Test Author"},
-            "blocks": [
-                {"id": "intro", "type": "text", "content": "Introduction"}
-            ],
+            "blocks": [{"id": "intro", "type": "text", "content": "Introduction"}],
         }
     }
 
@@ -241,9 +235,7 @@ def test_document_from_json():
             "article": {
                 "title": "Test Document",
                 "metadata": {"author": "Test Author"},
-                "blocks": [
-                    {"id": "intro", "type": "text", "content": "Introduction"}
-                ],
+                "blocks": [{"id": "intro", "type": "text", "content": "Introduction"}],
             }
         }
     )

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -180,9 +180,7 @@ def test_document_move_block():
 
 def test_document_to_dict():
     """Test to_dict method"""
-    doc = BlockDocDocument(
-        {"title": "Test Document", "metadata": {"author": "Test Author"}}
-    )
+    doc = BlockDocDocument({"title": "Test Document", "metadata": {"author": "Test Author"}})
 
     doc.add_block(Block.text("intro", "Introduction"))
 

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -75,7 +75,9 @@ def test_document_add_block():
 
     # Try adding a block with existing ID
     with pytest.raises(ValueError) as excinfo:
-        doc.add_block({"id": "intro", "type": "text", "content": "New introduction"})
+        doc.add_block(
+            {"id": "intro", "type": "text", "content": "New introduction"}
+        )
     assert "Block with ID 'intro' already exists" in str(excinfo.value)
 
 
@@ -122,7 +124,9 @@ def test_document_update_block():
     doc.add_block(Block.text("intro", "Introduction"))
 
     # Update the block
-    updated_block = doc.update_block("intro", {"content": "Updated introduction"})
+    updated_block = doc.update_block(
+        "intro", {"content": "Updated introduction"}
+    )
 
     assert updated_block["content"] == "Updated introduction"
     assert doc.article["blocks"][0]["content"] == "Updated introduction"
@@ -215,7 +219,9 @@ def test_document_from_dict():
         "article": {
             "title": "Test Document",
             "metadata": {"author": "Test Author"},
-            "blocks": [{"id": "intro", "type": "text", "content": "Introduction"}],
+            "blocks": [
+                {"id": "intro", "type": "text", "content": "Introduction"}
+            ],
         }
     }
 
@@ -235,7 +241,9 @@ def test_document_from_json():
             "article": {
                 "title": "Test Document",
                 "metadata": {"author": "Test Author"},
-                "blocks": [{"id": "intro", "type": "text", "content": "Introduction"}],
+                "blocks": [
+                    {"id": "intro", "type": "text", "content": "Introduction"}
+                ],
             }
         }
     )


### PR DESCRIPTION
- New `markdown_to_blockdoc` converter for transforming Markdown documents to BlockDoc format
- Comprehensive parser that handles all core Markdown elements:
  - Headings (ATX and Setext styles)
  - Paragraphs with proper line break handling
  - Lists (ordered and unordered)
  - Code blocks with language detection
  - Block quotes with attribution
  - Images with captions
  - Horizontal rules
- Semantic ID generation based on content
- Example implementation in `examples/markdown_conversion_example.py`
- Test suite for the converter functionality